### PR TITLE
feat/i24 :bug: [REST] - Adição de Validação no Método createShelter

### DIFF
--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/ShelterEntityServiceImpl.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/ShelterEntityServiceImpl.java
@@ -42,6 +42,7 @@ public class ShelterEntityServiceImpl implements ShelterEntityService {
     public static final String ADDRESS_CREATION_ERROR = "Erro na criação do endereço. Confirme se todos os campos do endereço estão corretos e tente novamente.";
     public static final String ERROR_MAPPING_ADDRESS = "Erro durante o mapeamento do endereço para persistência";
     public static final String USER_RESPONSIBLE_EMAIL_NOT_FOUND_ERROR = "Ops! Não conseguimos encontrar o e-mail do usuário responsável. Por gentileza, tente novamente.";
+    public static final String REQUEST_VALIDATION_ERROR_MESSAGE = "Por favor, forneça uma requisição de criação de Abrigo preenchida corretamente.";
 
 
     private final ShelterRepository repository;
@@ -77,6 +78,7 @@ public class ShelterEntityServiceImpl implements ShelterEntityService {
      */
     @Override
     public ShelterCreatedResponse createShelter(ShelterCreationRequest request) {
+        ValidationUtils.validateNotNullOrEmpty(request, REQUEST_VALIDATION_ERROR_MESSAGE, ShelterEntityFailuresException.class);
         ShelterContract shelterContract = this.createAndReturnShelterInstance(request);
         ShelterEntity shelterEntity = this.mapShelterAndSaveToRepository(shelterContract);
         return constructShelterCreatedResponse(shelterEntity);

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/ShelterEntityServiceImplTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/ShelterEntityServiceImplTest.java
@@ -66,11 +66,6 @@ class ShelterEntityServiceImplTest {
     public static final String STATE = "Estado";
     public static final String ZIP = "98456123";
 
-    public static final String DONATION_ID = "bf9b8d38-c6b3-4fd6-9b8d-38c6b3bfd69f";
-    public static final String DONATION_DESCRIPTION = "Descrição";
-    public static final int AMOUNT = 1;
-
-    public static final String ENTITY_ID = "b7a89acb-c03f-4f87-a89a-cbc03fef8755";
 
 
     @InjectMocks
@@ -467,6 +462,19 @@ class ShelterEntityServiceImplTest {
         assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.SHELTER_CREATION_ERROR_MESSAGE), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
+    }
+
+    @Test
+    void shouldThrowShelterEntityFailuresExceptionWhenCreatingShelterWithNullArgument() {
+
+        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(null));
+
+        verify(this.addressRepository, never()).save(any(AddressEntity.class));
+        verify(this.repository, never()).persist(any(ShelterContract.class));
+
+        assertNotNull(exception);
+        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.REQUEST_VALIDATION_ERROR_MESSAGE), exception.getMessage());
+        assertNull(exception.getCause());
     }
 
 }


### PR DESCRIPTION
# Solicitação de Pull Request

## Status

- [x] In Progress
- [x] Ready to Merging

## Tipo

- [ ] Release
- [ ] Feature
- [x] Technical Debt
- [ ] Fix
- [ ] Test
- [ ] Refactor
- [ ] Documentation
- [ ] Performance

## Descrição

**Commit** b1a01823449146c4a727faec3f6341698e867109:

Este commit adiciona uma validação ao método `createShelter` para garantir que uma solicitação de criação de abrigo não seja nula. Também foi incluído um novo teste para verificar a exceção lançada quando uma solicitação nula é passada. Essas mudanças visam evitar erros causados por solicitações de criação nulas e fornecer mensagens de erro mais claras para o usuário.

**Arquivos Alterados:** `ShelterEntityServiceImpl.java`, `ShelterEntityServiceImplTest.java`

**Alterações:**

- Adicionada a validação `ValidationUtils.validateNotNullOrEmpty` no método `createShelter` de `ShelterEntityServiceImpl` para verificar se o pedido de criação de um abrigo não é nulo.
- Incluído o campo `REQUEST_VALIDATION_ERROR_MESSAGE` em `ShelterEntityServiceImpl`.
- Adicionado o teste `shouldThrowShelterEntityFailuresExceptionWhenCreatingShelterWithNullArgument` em `ShelterEntityServiceImplTest` para verificar a exceção lançada quando uma solicitação nula é passada para `createShelter`.

**Nota:** A principal ênfase desta confirmação é adicionar uma validação de solicitação nula no método `createShelter` e fornecer mensagens de erro claras quando uma solicitação nula é passada.