### PR TITLE
feat/i34 :sparkles:  [REST] - Criação de Classe de Serviço para a Entity Address

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Conectar Doações
+# Conectar Doações [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=conectar-doacoes&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=conectar-doacoes) [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=conectar-doacoes&metric=coverage)](https://sonarcloud.io/summary/new_code?id=conectar-doacoes) [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=conectar-doacoes&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=conectar-doacoes)
+
 
 O `Conectar Doações` é uma plataforma de conexão de doadores e organizações/receptores de doações. Buscamos junto à
 tecnologia ajudar a fazer a diferença na vida das pessoas, tornando mais fácil a prática de doações a quem precisa. 

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/AddressEntityService.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/AddressEntityService.java
@@ -1,0 +1,40 @@
+package diegosneves.github.conectardoacoes.adapters.rest.service;
+
+import diegosneves.github.conectardoacoes.adapters.rest.dto.AddressDTO;
+import diegosneves.github.conectardoacoes.adapters.rest.exception.AddressEntityFailuresException;
+import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Address;
+
+/**
+ * A Interface {@link AddressEntityService} é responsável pela manipulação de entidades de endereços na camada de serviço
+ * do sistema. Possui métodos que traduzem os requerimentos de negócio da aplicação para operações realizadas na
+ * camada de persistência de dados.
+ * <p>
+ * Como parte de suas responsabilidades, lida com a conversão entre DTOs e entidades de endereço, garantindo
+ * a validação necessária dos dados e gerenciando o processo de persistência na base de dados.
+ * <p>
+ * Os serviços oferecidos por esta interface incluem a criação de novas entidades de endereço a partir de DTOs de endereço,
+ * possuindo mecanismos de tratamento de exceções que são acionados quando há falhas durante esta criação.
+ * <p>
+ * Os métodos declarados devem ser implementados por uma classe de serviço concreta para que sejam executados.
+ *
+ * @author diegoneves
+ * @since 1.1.0
+ */
+public interface AddressEntityService {
+
+    /**
+     * Cria e salva uma entidade de endereço {@link Address} com base nas informações fornecidas no DTO de Endereço {@link AddressDTO}.
+     * <p>
+     * Este método recebe um objeto {@link AddressDTO}, que contém as informações de endereço, e retorna um objeto {@link Address},
+     * que representa a entidade de endereço criada e salva.
+     * <p>
+     * O processamento inclui a conversão do DTO de endereço em uma entidade de endereço, validando as informações e salvando a entidade na base de dados.
+     * Em caso de falha na criação da entidade de endereço, uma exceção {@link AddressEntityFailuresException} será lançada.
+     *
+     * @param address Um objeto {@link AddressDTO} contendo as informações do endereço para criação da entidade de endereço.
+     * @return A entidade de endereço {@link Address} criada e salva.
+     * @throws AddressEntityFailuresException Se ocorrer uma falha durante a criação da entidade de endereço.
+     */
+    Address createAndSaveAddressFromDto(AddressDTO address) throws AddressEntityFailuresException;
+
+}

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/AddressEntityServiceImpl.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/AddressEntityServiceImpl.java
@@ -1,0 +1,85 @@
+package diegosneves.github.conectardoacoes.adapters.rest.service.impl;
+
+import diegosneves.github.conectardoacoes.adapters.rest.dto.AddressDTO;
+import diegosneves.github.conectardoacoes.adapters.rest.exception.AddressEntityFailuresException;
+import diegosneves.github.conectardoacoes.adapters.rest.mapper.AddressEntityMapper;
+import diegosneves.github.conectardoacoes.adapters.rest.mapper.BuilderMapper;
+import diegosneves.github.conectardoacoes.adapters.rest.model.AddressEntity;
+import diegosneves.github.conectardoacoes.adapters.rest.repository.AddressRepository;
+import diegosneves.github.conectardoacoes.adapters.rest.service.AddressEntityService;
+import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Address;
+import diegosneves.github.conectardoacoes.core.domain.shelter.factory.AddressFactory;
+import diegosneves.github.conectardoacoes.core.exception.AddressCreationFailureException;
+import diegosneves.github.conectardoacoes.core.utils.ValidationUtils;
+import org.springframework.stereotype.Service;
+
+/**
+ * A classe {@link AddressEntityServiceImpl} é responsável por fornecer serviços relacionados ao endereço.
+ * Isso compreende a criação e armazenamento de um objeto endereço.
+ * Para o armazenamento é utilizado um repositório de endereços injetado no serviço como dependência.
+ * <p>
+ * Ao iniciar, o serviço valida se o objeto endereço não é nulo nem vazio.
+ * Em caso de falha na validação, é lançada uma exceção {@link AddressEntityFailuresException} com a mensagem específica.
+ * <p>
+ * Depois, é criada uma nova instância de {@link Address} usando {@link AddressFactory}, que pode gerar exceções durante a criação,
+ * as quais são capturadas e tratadas, emitindo novas {@link AddressEntityFailuresException} em caso de erros.
+ * <p>
+ * Por fim, o serviço faz uso do objeto {@link Address} criado para armazená-lo no repositório correspondente,
+ * e retorna o objeto armazenado.
+ * <p>
+ * A classe oferece dois métodos principais:</p>
+ * <ol>
+ *     <li><code>createAndSaveAddressFromDto</code> que cria um endereço a partir de um DTO e o salva no repositório.</li>
+ *     <li><code>mapAddressAndSaveToRepository</code> que trata do mapeamento do objeto endereço para a entidade correspondente e posterior armazenamento no repositório.</li>
+ * </ol>
+ * <p>
+ * Implementa a interface {@link AddressEntityService}.
+ *
+ * @author diegoneves
+ * @since 1.1.0
+ */
+@Service
+public class AddressEntityServiceImpl implements AddressEntityService {
+
+    public static final String ADDRESS_CREATION_ERROR = "Erro na criação do endereço. Confirme se todos os campos do endereço estão corretos e tente novamente.";
+    public static final String ERROR_MAPPING_ADDRESS = "Erro durante o mapeamento do endereço para persistência";
+
+
+    private final AddressRepository repository;
+
+    public AddressEntityServiceImpl(AddressRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Address createAndSaveAddressFromDto(AddressDTO address) throws AddressEntityFailuresException {
+        ValidationUtils.validateNotNullOrEmpty(address, ADDRESS_CREATION_ERROR, AddressEntityFailuresException.class);
+        Address newAddress;
+        try {
+            newAddress = AddressFactory.create(address.getStreet(), address.getNumber(), address.getNeighborhood(), address.getCity(), address.getState(), address.getZip());
+        } catch (AddressCreationFailureException e) {
+            throw new AddressEntityFailuresException(ADDRESS_CREATION_ERROR, e);
+        }
+        this.mapAddressAndSaveToRepository(newAddress);
+        return newAddress;
+    }
+
+    /**
+     * Este método é responsável por mapear um objeto de endereço para a entidade relevante e salvá-lo no repositório.
+     * Usa o {@link BuilderMapper} para mapear o endereço, depois salva no repositório.
+     *
+     * @param address - Um objeto de endereço que precisa ser mapeado e salvo.
+     * @throws AddressEntityFailuresException - Se ocorrer uma exceção durante o mapeamento, será lançada uma {@link AddressEntityFailuresException}.
+     *                                        A exceção original será anexada como causa.
+     */
+    private void mapAddressAndSaveToRepository(Address address) throws AddressEntityFailuresException {
+        AddressEntity addressEntity;
+        try {
+            addressEntity = BuilderMapper.mapTo(new AddressEntityMapper(), address);
+        } catch (RuntimeException e) {
+            throw new AddressEntityFailuresException(ERROR_MAPPING_ADDRESS, e);
+        }
+        this.repository.save(addressEntity);
+    }
+
+}

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/AddressEntityServiceImplTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/AddressEntityServiceImplTest.java
@@ -1,0 +1,300 @@
+package diegosneves.github.conectardoacoes.adapters.rest.service.impl;
+
+import diegosneves.github.conectardoacoes.adapters.rest.dto.AddressDTO;
+import diegosneves.github.conectardoacoes.adapters.rest.exception.AddressEntityFailuresException;
+import diegosneves.github.conectardoacoes.adapters.rest.mapper.AddressEntityMapper;
+import diegosneves.github.conectardoacoes.adapters.rest.mapper.BuilderMapper;
+import diegosneves.github.conectardoacoes.adapters.rest.model.AddressEntity;
+import diegosneves.github.conectardoacoes.adapters.rest.repository.AddressRepository;
+import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Address;
+import diegosneves.github.conectardoacoes.core.exception.AddressCreationFailureException;
+import diegosneves.github.conectardoacoes.core.utils.UuidUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(SpringExtension.class)
+class AddressEntityServiceImplTest {
+
+    public static final String STREET = "Rua";
+    public static final String NUMBER = "298";
+    public static final String NEIGHBORHOOD = "Bairro";
+    public static final String CITY = "Cidade";
+    public static final String STATE = "Estado";
+    public static final String ZIP = "98456123";
+
+    @InjectMocks
+    private AddressEntityServiceImpl service;
+
+    @Mock
+    private AddressRepository repository;
+
+    @Captor
+    private ArgumentCaptor<AddressEntity> addressCaptor;
+
+    private AddressDTO addressDTO;
+
+    @BeforeEach
+    void setUp() {
+        this.addressDTO = AddressDTO.builder()
+                .street(STREET)
+                .number(NUMBER)
+                .neighborhood(NEIGHBORHOOD)
+                .city(CITY)
+                .state(STATE)
+                .zip(ZIP)
+                .build();
+    }
+
+    @Test
+    void shouldSaveAddressEntityAndReturnAddress() {
+
+        Address address = this.service.createAndSaveAddressFromDto(this.addressDTO);
+
+        verify(this.repository, times(1)).save(this.addressCaptor.capture());
+
+        assertNotNull(address);
+        AddressEntity addressEntity = this.addressCaptor.getValue();
+        assertNotNull(addressEntity);
+        assertTrue(UuidUtils.isValidUUID(addressEntity.getId()));
+        assertTrue(UuidUtils.isValidUUID(address.getId()));
+        assertEquals(STREET, addressEntity.getStreet());
+        assertEquals(NUMBER, addressEntity.getNumber());
+        assertEquals(NEIGHBORHOOD, addressEntity.getNeighborhood());
+        assertEquals(CITY, addressEntity.getCity());
+        assertEquals(STATE, addressEntity.getState());
+        assertEquals(ZIP, addressEntity.getZip());
+        assertEquals(addressEntity.getId(), address.getId());
+        assertEquals(address.getStreet(), addressEntity.getStreet());
+        assertEquals(address.getNumber(), addressEntity.getNumber());
+        assertEquals(address.getNeighborhood(), addressEntity.getNeighborhood());
+        assertEquals(address.getCity(), addressEntity.getCity());
+        assertEquals(address.getState(), addressEntity.getState());
+        assertEquals(address.getZip(), addressEntity.getZip());
+    }
+
+    @Test
+    void mapAddressAndSaveToRepositoryThrowsExceptionWhenAddressIsNull() {
+
+        try (MockedStatic<BuilderMapper> mockedBuilder = mockStatic(BuilderMapper.class)) {
+
+            mockedBuilder.when(() -> BuilderMapper.mapTo(any(AddressEntityMapper.class), any(Address.class))).thenThrow(IllegalArgumentException.class);
+
+            AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.service.createAndSaveAddressFromDto(this.addressDTO));
+
+            verify(this.repository, never()).save(any(AddressEntity.class));
+
+            assertNotNull(exception);
+            assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ERROR_MAPPING_ADDRESS), exception.getMessage());
+            assertNotNull(exception.getCause());
+            assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
+        }
+    }
+
+
+    @Test
+    void shouldThrowAddressEntityFailuresExceptionWhenAddressDtoIsNull() {
+
+        AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.service.createAndSaveAddressFromDto(null));
+
+        verify(this.repository, never()).save(any(AddressEntity.class));
+
+        assertNotNull(exception);
+        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertNull(exception.getCause());
+    }
+
+    @Test
+    void shouldThrowAddressEntityFailuresExceptionWhenAddressDtoStreetNameIsNull() {
+        this.addressDTO.setStreet(null);
+
+        AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.service.createAndSaveAddressFromDto(this.addressDTO));
+
+        verify(this.repository, never()).save(any(AddressEntity.class));
+
+        assertNotNull(exception);
+        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertNotNull(exception.getCause());
+        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"  ", ""})
+    void shouldThrowAddressEntityFailuresExceptionWhenAddressDtoStreetNameIsBlank(String addressStreet) {
+        this.addressDTO.setStreet(addressStreet);
+
+        AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.service.createAndSaveAddressFromDto(this.addressDTO));
+
+        verify(this.repository, never()).save(any(AddressEntity.class));
+
+        assertNotNull(exception);
+        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertNotNull(exception.getCause());
+        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
+    }
+
+    @Test
+    void shouldThrowAddressEntityFailuresExceptionWhenAddressDtoNumberIsNull() {
+        this.addressDTO.setNumber(null);
+
+        AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.service.createAndSaveAddressFromDto(this.addressDTO));
+
+        verify(this.repository, never()).save(any(AddressEntity.class));
+
+        assertNotNull(exception);
+        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertNotNull(exception.getCause());
+        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"  ", ""})
+    void shouldThrowAddressEntityFailuresExceptionWhenAddressDtoNumberIsBlank(String value) {
+        this.addressDTO.setNumber(value);
+
+        AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.service.createAndSaveAddressFromDto(this.addressDTO));
+
+        verify(this.repository, never()).save(any(AddressEntity.class));
+
+        assertNotNull(exception);
+        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertNotNull(exception.getCause());
+        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
+    }
+
+    @Test
+    void shouldThrowAddressEntityFailuresExceptionWhenAddressDtoNeighborhoodIsNull() {
+        this.addressDTO.setNeighborhood(null);
+
+        AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.service.createAndSaveAddressFromDto(this.addressDTO));
+
+        verify(this.repository, never()).save(any(AddressEntity.class));
+
+        assertNotNull(exception);
+        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertNotNull(exception.getCause());
+        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"  ", ""})
+    void shouldThrowAddressEntityFailuresExceptionWhenAddressDtoNeighborhoodIsBlank(String value) {
+        this.addressDTO.setNeighborhood(value);
+
+        AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.service.createAndSaveAddressFromDto(this.addressDTO));
+
+        verify(this.repository, never()).save(any(AddressEntity.class));
+
+        assertNotNull(exception);
+        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertNotNull(exception.getCause());
+        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
+    }
+
+    @Test
+    void shouldThrowAddressEntityFailuresExceptionWhenAddressDtoCityIsNull() {
+        this.addressDTO.setCity(null);
+
+        AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.service.createAndSaveAddressFromDto(this.addressDTO));
+
+        verify(this.repository, never()).save(any(AddressEntity.class));
+
+        assertNotNull(exception);
+        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertNotNull(exception.getCause());
+        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"  ", ""})
+    void shouldThrowAddressEntityFailuresExceptionWhenAddressDtoCityIsBlank(String value) {
+        this.addressDTO.setCity(value);
+
+        AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.service.createAndSaveAddressFromDto(this.addressDTO));
+
+        verify(this.repository, never()).save(any(AddressEntity.class));
+
+        assertNotNull(exception);
+        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertNotNull(exception.getCause());
+        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
+    }
+
+    @Test
+    void shouldThrowAddressEntityFailuresExceptionWhenAddressDtoStateIsNullInCreateShelter() {
+        this.addressDTO.setState(null);
+
+        AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.service.createAndSaveAddressFromDto(this.addressDTO));
+
+        verify(this.repository, never()).save(any(AddressEntity.class));
+
+        assertNotNull(exception);
+        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertNotNull(exception.getCause());
+        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"  ", ""})
+    void shouldThrowAddressEntityFailuresExceptionWhenAddressDtoStateIsBlankInCreateShelter(String value) {
+        this.addressDTO.setState(value);
+
+        AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.service.createAndSaveAddressFromDto(this.addressDTO));
+
+        verify(this.repository, never()).save(any(AddressEntity.class));
+
+        assertNotNull(exception);
+        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertNotNull(exception.getCause());
+        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
+    }
+
+    @Test
+    void shouldThrowAddressEntityFailuresExceptionWhenAddressDtoZipCodeIsNull() {
+        this.addressDTO.setZip(null);
+
+        AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.service.createAndSaveAddressFromDto(this.addressDTO));
+
+        verify(this.repository, never()).save(any(AddressEntity.class));
+
+        assertNotNull(exception);
+        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertNotNull(exception.getCause());
+        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"  ", ""})
+    void shouldThrowAddressEntityFailuresExceptionWhenAddressDtoZipCodeIsBlank(String value) {
+        this.addressDTO.setZip(value);
+
+        AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.service.createAndSaveAddressFromDto(this.addressDTO));
+
+        verify(this.repository, never()).save(any(AddressEntity.class));
+
+        assertNotNull(exception);
+        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertNotNull(exception.getCause());
+        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
+    }
+
+}

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/ShelterEntityServiceImplTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/ShelterEntityServiceImplTest.java
@@ -2,24 +2,21 @@ package diegosneves.github.conectardoacoes.adapters.rest.service.impl;
 
 import diegosneves.github.conectardoacoes.adapters.rest.dto.AddressDTO;
 import diegosneves.github.conectardoacoes.adapters.rest.enums.UserProfileType;
+import diegosneves.github.conectardoacoes.adapters.rest.exception.AddressEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.ShelterEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.UserEntityFailuresException;
-import diegosneves.github.conectardoacoes.adapters.rest.mapper.AddressEntityMapper;
 import diegosneves.github.conectardoacoes.adapters.rest.mapper.BuilderMapper;
-import diegosneves.github.conectardoacoes.adapters.rest.model.AddressEntity;
-import diegosneves.github.conectardoacoes.adapters.rest.model.DonationEntity;
-import diegosneves.github.conectardoacoes.adapters.rest.repository.AddressRepository;
-import diegosneves.github.conectardoacoes.adapters.rest.repository.DonationRepository;
+import diegosneves.github.conectardoacoes.adapters.rest.mapper.ShelterEntityMapper;
 import diegosneves.github.conectardoacoes.adapters.rest.repository.ShelterRepository;
 import diegosneves.github.conectardoacoes.adapters.rest.request.ShelterCreationRequest;
 import diegosneves.github.conectardoacoes.adapters.rest.response.ShelterCreatedResponse;
+import diegosneves.github.conectardoacoes.adapters.rest.service.AddressEntityService;
 import diegosneves.github.conectardoacoes.adapters.rest.service.UserEntityService;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.Shelter;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.ShelterContract;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Address;
 import diegosneves.github.conectardoacoes.core.domain.user.entity.User;
 import diegosneves.github.conectardoacoes.core.domain.user.entity.value.UserProfile;
-import diegosneves.github.conectardoacoes.core.exception.AddressCreationFailureException;
 import diegosneves.github.conectardoacoes.core.exception.ShelterCreationFailureException;
 import diegosneves.github.conectardoacoes.core.utils.UuidUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -78,26 +76,20 @@ class ShelterEntityServiceImplTest {
     private UserEntityService userEntityService;
 
     @Mock
-    private DonationRepository donationRepository;
-
-    @Mock
-    private AddressRepository addressRepository;
+    private AddressEntityService addressService;
 
     @Captor
     private ArgumentCaptor<ShelterContract> shelterCaptor;
 
-    @Captor
-    private ArgumentCaptor<AddressEntity> addressCaptor;
 
     private ShelterCreationRequest request;
-    private AddressDTO addressDTO;
     private User user;
     private Shelter shelter;
     private Address address;
 
     @BeforeEach
     void setUp() {
-        this.addressDTO = AddressDTO.builder()
+        AddressDTO addressDTO = AddressDTO.builder()
                 .street(STREET)
                 .number(NUMBER)
                 .neighborhood(NEIGHBORHOOD)
@@ -108,7 +100,7 @@ class ShelterEntityServiceImplTest {
 
         this.request = ShelterCreationRequest.builder()
                 .shelterName(SHELTER_NAME)
-                .address(this.addressDTO)
+                .address(addressDTO)
                 .responsibleUserEmail(USER_EMAIL)
                 .build();
 
@@ -119,17 +111,15 @@ class ShelterEntityServiceImplTest {
 
     @Test
     void shouldCreateShelter() {
-        AddressEntity addressEntity = new AddressEntityMapper().mapFrom(this.address);
         when(this.userEntityService.searchUserByEmail(USER_EMAIL)).thenReturn(this.user);
-        when(this.addressRepository.save(any(AddressEntity.class))).thenReturn(addressEntity);
+        when(this.addressService.createAndSaveAddressFromDto(any(AddressDTO.class))).thenReturn(this.address);
         when(this.repository.persist(any(ShelterContract.class))).thenReturn(this.shelter);
 
         ShelterCreatedResponse response = this.service.createShelter(this.request);
 
         verify(this.userEntityService, times(1)).searchUserByEmail(USER_EMAIL);
-        verify(this.addressRepository, times(1)).save(addressCaptor.capture());
-        verify(this.repository, times(1)).persist(shelterCaptor.capture());
-        verify(this.donationRepository, never()).save(any(DonationEntity.class));
+        verify(this.addressService, times(1)).createAndSaveAddressFromDto(any(AddressDTO.class));
+        verify(this.repository, times(1)).persist(this.shelterCaptor.capture());
 
         assertNotNull(response);
         assertEquals(SHELTER_ID, response.getId());
@@ -145,26 +135,24 @@ class ShelterEntityServiceImplTest {
         assertEquals(USER_EMAIL, response.getResponsibleUser().getEmail());
         assertNotNull(response.getResponsibleUser().getUserProfile());
         assertEquals(UserProfileType.DONOR, response.getResponsibleUser().getUserProfile());
-        assertNotNull(shelterCaptor.getValue());
-        assertTrue(UuidUtils.isValidUUID(shelterCaptor.getValue().getId()));
-        assertEquals(SHELTER_NAME, shelterCaptor.getValue().getShelterName());
-        assertNotNull(shelterCaptor.getValue().getDonations());
-        assertTrue(shelterCaptor.getValue().getDonations().isEmpty());
-        assertNotNull(shelterCaptor.getValue().getAddress());
-        assertNotNull(addressCaptor.getValue());
-        assertTrue(UuidUtils.isValidUUID(addressCaptor.getValue().getId()));
-        assertEquals(STREET, shelterCaptor.getValue().getAddress().getStreet());
-        assertEquals(NUMBER, shelterCaptor.getValue().getAddress().getNumber());
-        assertEquals(NEIGHBORHOOD, shelterCaptor.getValue().getAddress().getNeighborhood());
-        assertEquals(CITY, shelterCaptor.getValue().getAddress().getCity());
-        assertEquals(STATE, shelterCaptor.getValue().getAddress().getState());
-        assertEquals(ZIP, shelterCaptor.getValue().getAddress().getZip());
-        assertNotNull(shelterCaptor.getValue().getUser());
-        assertTrue(UuidUtils.isValidUUID(shelterCaptor.getValue().getUser().getId()));
-        assertEquals(USER_NAME, shelterCaptor.getValue().getUser().getUsername());
-        assertEquals(USER_EMAIL, shelterCaptor.getValue().getUser().getEmail());
-        assertEquals(UserProfile.DONOR, shelterCaptor.getValue().getUser().getUserProfile());
-        assertEquals(USER_PASSWORD, shelterCaptor.getValue().getUser().getUserPassword());
+        assertNotNull(this.shelterCaptor.getValue());
+        assertTrue(UuidUtils.isValidUUID(this.shelterCaptor.getValue().getId()));
+        assertEquals(SHELTER_NAME, this.shelterCaptor.getValue().getShelterName());
+        assertNotNull(this.shelterCaptor.getValue().getDonations());
+        assertTrue(this.shelterCaptor.getValue().getDonations().isEmpty());
+        assertNotNull(this.shelterCaptor.getValue().getAddress());
+        assertEquals(STREET, this.shelterCaptor.getValue().getAddress().getStreet());
+        assertEquals(NUMBER, this.shelterCaptor.getValue().getAddress().getNumber());
+        assertEquals(NEIGHBORHOOD, this.shelterCaptor.getValue().getAddress().getNeighborhood());
+        assertEquals(CITY, this.shelterCaptor.getValue().getAddress().getCity());
+        assertEquals(STATE, this.shelterCaptor.getValue().getAddress().getState());
+        assertEquals(ZIP, this.shelterCaptor.getValue().getAddress().getZip());
+        assertNotNull(this.shelterCaptor.getValue().getUser());
+        assertTrue(UuidUtils.isValidUUID(this.shelterCaptor.getValue().getUser().getId()));
+        assertEquals(USER_NAME, this.shelterCaptor.getValue().getUser().getUsername());
+        assertEquals(USER_EMAIL, this.shelterCaptor.getValue().getUser().getEmail());
+        assertEquals(UserProfile.DONOR, this.shelterCaptor.getValue().getUser().getUserProfile());
+        assertEquals(USER_PASSWORD, this.shelterCaptor.getValue().getUser().getUserPassword());
     }
 
     @ParameterizedTest
@@ -196,205 +184,6 @@ class ShelterEntityServiceImplTest {
         assertEquals(ShelterCreationFailureException.class, exception.getCause().getClass());
     }
 
-    @Test
-    void shouldThrowShelterEntityFailuresExceptionWhenAddressDtoIsNullInCreateShelter() {
-        this.request.setAddress(null);
-
-        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(this.request));
-
-        verify(this.repository, never()).persist(any(ShelterContract.class));
-        verify(this.addressRepository, never()).save(any(AddressEntity.class));
-
-        assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
-        assertNull(exception.getCause());
-    }
-
-    @Test
-    void shouldThrowShelterEntityFailuresExceptionWhenAddressDtoStreetNameIsNullInCreateShelter() {
-        this.addressDTO.setStreet(null);
-
-        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(this.request));
-
-        verify(this.repository, never()).persist(any(ShelterContract.class));
-        verify(this.addressRepository, never()).save(any(AddressEntity.class));
-
-        assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
-        assertNotNull(exception.getCause());
-        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"  ", ""})
-    void shouldThrowShelterEntityFailuresExceptionWhenAddressDtoStreetNameIsBlankInCreateShelter(String addressStreet) {
-        this.addressDTO.setStreet(addressStreet);
-
-        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(this.request));
-
-        verify(this.repository, never()).persist(any(ShelterContract.class));
-        verify(this.addressRepository, never()).save(any(AddressEntity.class));
-
-        assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
-        assertNotNull(exception.getCause());
-        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
-    }
-
-    @Test
-    void shouldThrowShelterEntityFailuresExceptionWhenAddressDtoNumberIsNullInCreateShelter() {
-        this.addressDTO.setNumber(null);
-
-        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(this.request));
-
-        verify(this.repository, never()).persist(any(ShelterContract.class));
-        verify(this.addressRepository, never()).save(any(AddressEntity.class));
-
-        assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
-        assertNotNull(exception.getCause());
-        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"  ", ""})
-    void shouldThrowShelterEntityFailuresExceptionWhenAddressDtoNumberIsBlankInCreateShelter(String value) {
-        this.addressDTO.setNumber(value);
-
-        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(this.request));
-
-        verify(this.repository, never()).persist(any(ShelterContract.class));
-        verify(this.addressRepository, never()).save(any(AddressEntity.class));
-
-        assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
-        assertNotNull(exception.getCause());
-        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
-    }
-
-    @Test
-    void shouldThrowShelterEntityFailuresExceptionWhenAddressDtoNeighborhoodIsNullInCreateShelter() {
-        this.addressDTO.setNeighborhood(null);
-
-        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(this.request));
-
-        verify(this.repository, never()).persist(any(ShelterContract.class));
-        verify(this.addressRepository, never()).save(any(AddressEntity.class));
-
-        assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
-        assertNotNull(exception.getCause());
-        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"  ", ""})
-    void shouldThrowShelterEntityFailuresExceptionWhenAddressDtoNeighborhoodIsBlankInCreateShelter(String value) {
-        this.addressDTO.setNeighborhood(value);
-
-        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(this.request));
-
-        verify(this.repository, never()).persist(any(ShelterContract.class));
-        verify(this.addressRepository, never()).save(any(AddressEntity.class));
-
-        assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
-        assertNotNull(exception.getCause());
-        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
-    }
-
-    @Test
-    void shouldThrowShelterEntityFailuresExceptionWhenAddressDtoCityIsNullInCreateShelter() {
-        this.addressDTO.setCity(null);
-
-        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(this.request));
-
-        verify(this.repository, never()).persist(any(ShelterContract.class));
-        verify(this.addressRepository, never()).save(any(AddressEntity.class));
-
-        assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
-        assertNotNull(exception.getCause());
-        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"  ", ""})
-    void shouldThrowShelterEntityFailuresExceptionWhenAddressDtoCityIsBlankInCreateShelter(String value) {
-        this.addressDTO.setCity(value);
-
-        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(this.request));
-
-        verify(this.repository, never()).persist(any(ShelterContract.class));
-        verify(this.addressRepository, never()).save(any(AddressEntity.class));
-
-        assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
-        assertNotNull(exception.getCause());
-        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
-    }
-
-    @Test
-    void shouldThrowShelterEntityFailuresExceptionWhenAddressDtoStateIsNullInCreateShelter() {
-        this.addressDTO.setState(null);
-
-        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(this.request));
-
-        verify(this.repository, never()).persist(any(ShelterContract.class));
-        verify(this.addressRepository, never()).save(any(AddressEntity.class));
-
-        assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
-        assertNotNull(exception.getCause());
-        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"  ", ""})
-    void shouldThrowShelterEntityFailuresExceptionWhenAddressDtoStateIsBlankInCreateShelter(String value) {
-        this.addressDTO.setState(value);
-
-        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(this.request));
-
-        verify(this.repository, never()).persist(any(ShelterContract.class));
-        verify(this.addressRepository, never()).save(any(AddressEntity.class));
-
-        assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
-        assertNotNull(exception.getCause());
-        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
-    }
-
-    @Test
-    void shouldThrowShelterEntityFailuresExceptionWhenAddressDtoZipCodeIsNullInCreateShelter() {
-        this.addressDTO.setZip(null);
-
-        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(this.request));
-
-        verify(this.repository, never()).persist(any(ShelterContract.class));
-        verify(this.addressRepository, never()).save(any(AddressEntity.class));
-
-        assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
-        assertNotNull(exception.getCause());
-        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"  ", ""})
-    void shouldThrowShelterEntityFailuresExceptionWhenAddressDtoZipCodeIsBlankInCreateShelter(String value) {
-        this.addressDTO.setZip(value);
-
-        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(this.request));
-
-        verify(this.repository, never()).persist(any(ShelterContract.class));
-        verify(this.addressRepository, never()).save(any(AddressEntity.class));
-
-        assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
-        assertNotNull(exception.getCause());
-        assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
-    }
 
     @ParameterizedTest
     @ValueSource(strings = {"", "  "})
@@ -428,40 +217,25 @@ class ShelterEntityServiceImplTest {
     }
 
 
-    @Test
-    void mapAddressAndSaveToRepositoryThrowsExceptionWhenAddressIsNull() {
 
-        try (MockedStatic<BuilderMapper> mockedBuilder = mockStatic(BuilderMapper.class)) {
-
-            mockedBuilder.when(() -> BuilderMapper.mapTo(any(AddressEntityMapper.class), any(Address.class))).thenThrow(IllegalArgumentException.class);
-
-            ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(this.request));
-
-            verify(this.addressRepository, never()).save(any(AddressEntity.class));
-            verify(this.repository, never()).persist(any(ShelterContract.class));
-
-            assertNotNull(exception);
-            assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.ERROR_MAPPING_ADDRESS), exception.getMessage());
-            assertNotNull(exception.getCause());
-            assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
-        }
-    }
 
     @Test
     void mapShelterAndSaveToRepositoryThrowsExceptionWhenAddressIsNull() {
+        this.request.setAddress(null);
 
         when(this.userEntityService.searchUserByEmail(anyString())).thenReturn(this.user);
+        when(this.addressService.createAndSaveAddressFromDto(null)).thenThrow(AddressEntityFailuresException.class);
         when(this.repository.persist(any(ShelterContract.class))).thenReturn(null);
 
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(this.request));
 
-        verify(this.addressRepository, times(1)).save(any(AddressEntity.class));
-        verify(this.repository, times(1)).persist(any(ShelterContract.class));
+        verify(this.addressService, times(1)).createAndSaveAddressFromDto(null);
+        verify(this.repository, never()).persist(any(ShelterContract.class));
 
         assertNotNull(exception);
         assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.SHELTER_CREATION_ERROR_MESSAGE), exception.getMessage());
         assertNotNull(exception.getCause());
-        assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
+        assertEquals(AddressEntityFailuresException.class, exception.getCause().getClass());
     }
 
     @Test
@@ -469,12 +243,34 @@ class ShelterEntityServiceImplTest {
 
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(null));
 
-        verify(this.addressRepository, never()).save(any(AddressEntity.class));
+        verify(this.addressService, never()).createAndSaveAddressFromDto(any(AddressDTO.class));
         verify(this.repository, never()).persist(any(ShelterContract.class));
 
         assertNotNull(exception);
         assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.REQUEST_VALIDATION_ERROR_MESSAGE), exception.getMessage());
         assertNull(exception.getCause());
+    }
+
+    @Test
+    void mapShelterEntityFromShelterContractThrowsExceptionWhenShelterContractIsNull() {
+        when(this.userEntityService.searchUserByEmail(USER_EMAIL)).thenReturn(this.user);
+        when(this.addressService.createAndSaveAddressFromDto(any(AddressDTO.class))).thenReturn(this.address);
+        when(this.repository.persist(any(ShelterContract.class))).thenReturn(null);
+
+        try (MockedStatic<BuilderMapper> mockedBuilder = mockStatic(BuilderMapper.class)) {
+
+            mockedBuilder.when(() -> BuilderMapper.mapTo(any(ShelterEntityMapper.class), eq(null))).thenThrow(IllegalArgumentException.class);
+
+            ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.createShelter(this.request));
+
+            verify(this.addressService, times(1)).createAndSaveAddressFromDto(any(AddressDTO.class));
+            verify(this.repository, times(1)).persist(any(ShelterContract.class));
+
+            assertNotNull(exception);
+            assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.SHELTER_CREATION_ERROR_MESSAGE), exception.getMessage());
+            assertNotNull(exception.getCause());
+            assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
+        }
     }
 
 }


### PR DESCRIPTION
# Solicitação de Pull Request

## Status

- [x] In Progress
- [x] Ready to Merging

## Tipo

- [ ] Release
- [x] Feature
- [ ] Technical Debt
- [ ] Fix
- [ ] Test
- [ ] Refactor
- [ ] Documentation
- [ ] Performance

## Descrição

**Commit** 68b85312f52c9a999c6279671af8d6c388b6018a:

Este commit atualiza o serviço de criação de abrigos para usar `AddressEntityService`. O código foi refatorado para utilizar a classe AddressEntityService no processo de criação de abrigos em vez de diretamente tratar os dados do endereço. Isso simplifica a classe ShelterEntityServiceImpl, e melhora a separação de responsabilidades, pois agora a lógica de criação de endereços está inteiramente dentro de AddressEntityService.

**Arquivos Alterados:** `ShelterEntityServiceImpl.java`

**Alterações:**

- As referências à `AddressRepository` foram removidas de `ShelterEntityServiceImpl.java` e substituídas por `AddressEntityService`.
- O método `createAndReturnShelterInstance` de `ShelterEntityServiceImpl.java` foi alterado para usar `AddressEntityService.createAndSaveAddressFromDto(request.getAddress())` ao invés de criar e salvar o endereço diretamente.
- A lógica de criação e salvamento de endereços que estava em `ShelterEntityServiceImpl.java` foi movida para `AddressEntityService`.
- Os testes unitários em `ShelterEntityServiceImplTest.java` foram ajustados para refletir as mudanças feitas.

**Nota:** A principal ênfase desta confirmação é melhorar a separação de responsabilidades no serviço de criação de abrigos, movendo a lógica de criação de endereços para o próprio `AddressEntityService`.

---

**Commit** b25bb9dc76c73cc0e2b5315994c9170a23ff2703:

Este commit introduz um novo serviço chamado `AddressEntityServiceImpl`, responsável pela criação e gravação de entidades de endereço. Esse serviço aceita DTOs, valida, transforma-os em entidades de endereço e, em seguida, persiste-os no banco de dados. Em caso de falha, um tratamento de exceções foi implementado. Além disso, a interface `AddressEntityService` também foi criada, esta define o contrato para o serviço de endereço.

**Arquivos Alterados:** `AddressEntityService.java`, `AddressEntityServiceImpl.java`

**Alterações:**

- A interface `AddressEntityService` foi criada. Ela define o contrato para o serviço que lida com a entidade de endereço. A interface define um método chamado `createAndSaveAddressFromDto`, que é responsável por criar e salvar uma entidade de endereço com base em um DTO.

- A classe de serviço `AddressEntityServiceImpl` foi criada. Esta classe implementa a `AddressEntityService` e fornece a implementação para `createAndSaveAddressFromDto`. A implementação valida o DTO de entrada, cria a entidade de endereço e a persiste no banco de dados.

- Durante a criação da entidade de endereço, `AddressEntityServiceImpl` faz uso da `AddressFactory`. Se ocorrer algum erro durante a criação da entidade, `AddressCreationFailureException` será lançada.

- Para salvar a entidade no repositório, `AddressEntityServiceImpl` primeiro mapeia o objeto de endereço para a entidade relevante usando `BuilderMapper` e, em seguida, salva a entidade no repositório. Se ocorrer um erro durante o mapeamento, uma `AddressEntityFailuresException` será lançada.

- Em caso geral, se houver uma falha ao criar ou salvar a entidade de endereço, `AddressEntityFailuresException` será lançada.

**Nota:** A ênfase principal deste commit está na criação de um novo serviço dedicado ao gerenciamento de entidades de endereço. O serviço permite converter DTOs de endereço em entidades de endereço e persisti-las no banco de dados. O serviço também adiciona com robustez ao implementar tratamento de exceção adequado para situações onde a conversão ou persistência falha.

---

**Commit** f68969e62ba7b5d8b8d7f564e98792c48e2926fe:

Este commit adiciona uma série de testes para a implementação de `AddressEntityServiceImpl`. Os testes cobrem o comportamento esperado da implementação bem-sucedida, bem como tratamentos de erro quando há entradas inválidas ou nulas.

**Arquivo Alterado:** `AddressEntityServiceImplTest.java`

**Alterações:**

- Nova classe de teste `AddressEntityServiceImplTest` adicionada, com vários casos de teste.
- Os casos de teste verificam o comportamento esperado ao manipular o objeto `AddressDTO`, como a exceção apropriada sendo lançada quando o DTO está nulo ou quando campos individuais no DTO são nulos ou em branco.
- Uso extensivo de `MockedStatic`, `ArgumentCaptor` e `assertThrows` para verificar o comportamento do serviço `AddressEntityServiceImpl`.
   
**Nota:** Este commit se concentra na verificação dos casos de tratamento de erro, garantindo que a implementação `AddressEntityServiceImpl` se comporta como esperado quando encontrados dados inválidos ou nulos.
