### PR TITLE
feat/i26 :loud_sound: [REST] - Implementação de Logs para Monitoramento de Exceções

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ tecnologia ajudar a fazer a diferença na vida das pessoas, tornando mais fácil
 # Conteúdo
 - [Recursos](#Recursos)
 - [Arquitetura Hexagonal](#Arquitetura-Hexagonal)
+- [Javadoc](#javadoc)
 - [Swagger](#Swagger)
 - [Docker](#Docker)
   - [Como rodar o projeto com Docker](#como-rodar-o-projeto-com-docker)
@@ -32,6 +33,12 @@ tecnologia ajudar a fazer a diferença na vida das pessoas, tornando mais fácil
 ## Arquitetura Hexagonal
 Este projeto segue a arquitetura hexagonal, que é uma forma de organização de código que tem como objetivo tornar a base de código mais manutenível e desacoplada. Nesse modelo, a lógica de negócios central (domínio) é isolada das preocupações externas através do uso de portas e adaptadores (daí o nome "hexagonal").
 
+
+---
+
+## Javadoc
+
+A documentação detalhada gerada pelo Javadoc pode ser encontrada [aqui](https://diegosneves.github.io/conectar-doacoes/).
 
 ---
 

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/config/handler/ControllerExceptionHandler.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/config/handler/ControllerExceptionHandler.java
@@ -7,8 +7,10 @@ import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureE
 import diegosneves.github.conectardoacoes.adapters.rest.exception.ShelterEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.UserEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.model.UserEntity;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
  * @author diegosneves
  */
 @RestControllerAdvice
+@Slf4j
 public class ControllerExceptionHandler {
 
     /**
@@ -32,6 +35,25 @@ public class ControllerExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionDTO> handleFailures(Exception exception) {
         ExceptionDTO dto = new ExceptionDTO(exception.getMessage(), HttpStatus.BAD_REQUEST.value());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(dto);
+    }
+
+    /**
+     * Esta é uma função que lida com exceções do tipo {@link HttpMessageNotReadableException} em todo o controlador.
+     * Um objeto {@link HttpMessageNotReadableException} é lançado quando há um erro de sintaxe no corpo HTTP da solicitação.
+     * Este método captura essa exceção, registra uma mensagem de erro, cria um objeto {@link ExceptionDTO}
+     * contendo essa mensagem e um valor de retorno HTTP de {@code BAD_REQUEST} (400) e, em seguida, retorna essa entidade.
+     *
+     * @param exception A exceção {@link HttpMessageNotReadableException} que foi lançada quando ocorreu um erro de sintaxe no corpo HTTP de uma solicitação.
+     * @return Uma nova ResponseEntity contendo um objeto ExceptionDTO com a mensagem de erro e o status {@code BAD_REQUEST}.
+     * O valor de HttpStatus para {@code BAD_REQUEST} é 400, o que indica que a solicitação era inválida ou não pôde ser entendida pelo servidor.
+     * @apiNote {@link HttpMessageNotReadableException} Esta exceção é lançada quando ocorre um erro de sintaxe no corpo HTTP da solicitação, o que significa que a solicitação não pode ser lida.
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ExceptionDTO> handleJSONFailures(HttpMessageNotReadableException exception) {
+        String message = "Não foi possível processar o conteúdo da solicitação. Por favor, confira se os dados foram inseridos corretamente.";
+        ExceptionDTO dto = new ExceptionDTO(message, HttpStatus.BAD_REQUEST.value());
+        log.error(exception.getMessage(), exception);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(dto);
     }
 

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/AddressMapper.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/AddressMapper.java
@@ -6,6 +6,7 @@ import diegosneves.github.conectardoacoes.adapters.rest.model.AddressEntity;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Address;
 import diegosneves.github.conectardoacoes.core.exception.AddressCreationFailureException;
 import diegosneves.github.conectardoacoes.core.utils.ValidationUtils;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * A classe {@link AddressMapper} implementa a interface de estratégia de Mapeamento {@link MapperStrategy}
@@ -22,10 +23,12 @@ import diegosneves.github.conectardoacoes.core.utils.ValidationUtils;
  * @author diegoneves
  * @since 1.0.0
  */
+@Slf4j
 public class AddressMapper implements MapperStrategy<Address, AddressEntity> {
 
 
     public static final Class<AddressEntity> ADDRESS_ENTITY_TYPE = AddressEntity.class;
+    public static final String MAPPING_ERROR_LOG = "Ocorreu um erro durante o processo de mapeamento do objeto AddressEntity para Address. Detalhes do erro: {}";
 
     /**
      * Realiza a conversão de um objeto {@link AddressEntity} para um objeto {@link Address}.
@@ -46,6 +49,7 @@ public class AddressMapper implements MapperStrategy<Address, AddressEntity> {
         try {
             address = new Address(source.getId(), source.getStreet(), source.getNumber(), source.getNeighborhood(), source.getCity(), source.getState(), source.getZip());
         } catch (AddressCreationFailureException e) {
+            log.error(MAPPING_ERROR_LOG, e.getMessage(), e);
             throw new AddressEntityFailuresException(MapperFailureException.ERROR.formatErrorMessage(ADDRESS_ENTITY_TYPE.getSimpleName()), e);
         }
         return address;

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/DonationMapper.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/DonationMapper.java
@@ -6,6 +6,7 @@ import diegosneves.github.conectardoacoes.adapters.rest.model.DonationEntity;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Donation;
 import diegosneves.github.conectardoacoes.core.exception.DonationRegisterFailureException;
 import diegosneves.github.conectardoacoes.core.utils.ValidationUtils;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Esta classe implementa a interface {@link MapperStrategy} para mapear a entidade {@link DonationEntity} para o objeto de domínio {@link Donation}.
@@ -20,7 +21,10 @@ import diegosneves.github.conectardoacoes.core.utils.ValidationUtils;
  * @see DonationEntity
  * @see MapperStrategy
  */
+@Slf4j
 public class DonationMapper implements MapperStrategy<Donation, DonationEntity> {
+
+    public static final String MAPPING_ERROR_LOG = "Ocorreu um erro durante o processo de mapeamento do objeto DonationEntity para Donation. Detalhes do erro: {}";
 
     /**
      * Mapeia a entidade de doação do banco de dados para uma instância do objeto de domínio doação.
@@ -55,6 +59,7 @@ public class DonationMapper implements MapperStrategy<Donation, DonationEntity> 
         try {
             donation = new Donation(source.getId(), source.getDescription(), source.getAmount());
         } catch (DonationRegisterFailureException e) {
+            log.error(MAPPING_ERROR_LOG, e.getMessage(), e);
             throw new ShelterEntityFailuresException(MapperFailureException.ERROR.formatErrorMessage(DonationEntity.class.getSimpleName()), e);
         }
         return donation;

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/ShelterEntityMapper.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/ShelterEntityMapper.java
@@ -12,6 +12,7 @@ import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Addre
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Donation;
 import diegosneves.github.conectardoacoes.core.domain.user.entity.UserContract;
 import diegosneves.github.conectardoacoes.core.utils.ValidationUtils;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,9 +29,11 @@ import java.util.List;
  * @author diegoneves
  * @since 1.0.0
  */
+@Slf4j
 public class ShelterEntityMapper implements MapperStrategy<ShelterEntity, ShelterContract> {
 
     public static final Class<ShelterContract> SHELTER_CLASS = ShelterContract.class;
+    public static final String MAPPING_ERROR_LOG = "Ocorreu um erro durante o processo de mapeamento do objeto ShelterContract para ShelterEntity. Detalhes do erro: {}";
 
     /**
      * Método que converte a fonte, um objeto da classe {@link ShelterContract}, para um novo objeto da classe {@link ShelterEntity}.
@@ -59,6 +62,7 @@ public class ShelterEntityMapper implements MapperStrategy<ShelterEntity, Shelte
                     .donations(getDonationEntities(source.getDonations()))
                     .build();
         } catch (RuntimeException e) {
+            log.error(MAPPING_ERROR_LOG, e.getMessage(), e);
             throw new ShelterEntityFailuresException(MapperFailureException.ERROR.formatErrorMessage(SHELTER_CLASS.getSimpleName()), e);
         }
         return shelterEntity;

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/ShelterMapper.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/ShelterMapper.java
@@ -12,6 +12,7 @@ import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Donat
 import diegosneves.github.conectardoacoes.core.domain.user.entity.User;
 import diegosneves.github.conectardoacoes.core.exception.DonationRegisterFailureException;
 import diegosneves.github.conectardoacoes.core.utils.ValidationUtils;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Implementação da interface {@link MapperStrategy} para a conversão entre a entidade {@link ShelterEntity} e a classe de domínio {@link ShelterContract}.
@@ -22,9 +23,11 @@ import diegosneves.github.conectardoacoes.core.utils.ValidationUtils;
  * @see MapperStrategy
  * @since 1.0.0
  */
+@Slf4j
 public class ShelterMapper implements MapperStrategy<ShelterContract, ShelterEntity> {
 
     public static final Class<ShelterEntity> SHELTER_ENTITY_CLASS = ShelterEntity.class;
+    public static final String MAPPING_ERROR_LOG = "Ocorreu um erro durante o processo de mapeamento do objeto ShelterEntity para ShelterContract. Detalhes do erro: {}";
 
 
     /**
@@ -64,6 +67,7 @@ public class ShelterMapper implements MapperStrategy<ShelterContract, ShelterEnt
                     new AddressMapper().mapFrom(source.getAddress()),
                     new UserMapper().mapFrom(source.getResponsibleUser()));
         } catch (RuntimeException e) {
+            log.error(MAPPING_ERROR_LOG, e.getMessage(), e);
             throw new ShelterEntityFailuresException(MapperFailureException.ERROR.formatErrorMessage(SHELTER_ENTITY_CLASS.getSimpleName()), e);
         }
         this.mappedDonationsToShelter(source, constructedShelter);
@@ -96,6 +100,7 @@ public class ShelterMapper implements MapperStrategy<ShelterContract, ShelterEnt
             try {
                 constructedShelter.addDonation(new Donation(donationEntity.getId(), donationEntity.getDescription(), donationEntity.getAmount()));
             } catch (DonationRegisterFailureException e) {
+                log.error(MAPPING_ERROR_LOG, e.getMessage(), e);
                 throw new ShelterEntityFailuresException(MapperFailureException.ERROR.formatErrorMessage(Donation.class.getSimpleName()), e);
             }
         }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/UserEntityMapper.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/UserEntityMapper.java
@@ -7,6 +7,7 @@ import diegosneves.github.conectardoacoes.adapters.rest.model.UserEntity;
 import diegosneves.github.conectardoacoes.core.domain.user.entity.User;
 import diegosneves.github.conectardoacoes.core.domain.user.entity.UserContract;
 import diegosneves.github.conectardoacoes.core.utils.ValidationUtils;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * A classe {@code UserEntityMapper} implementa a interface {@link MapperStrategy} e é usada para mapear um objeto do tipo {@link User} para um objeto de entidade {@link UserEntity}.
@@ -17,9 +18,11 @@ import diegosneves.github.conectardoacoes.core.utils.ValidationUtils;
  * @author diegoneves
  * @since 1.0.0
  */
+@Slf4j
 public class UserEntityMapper implements MapperStrategy<UserEntity, UserContract> {
 
     public static final Class<UserContract> USER_CLASS = UserContract.class;
+    public static final String MAPPING_ERROR_LOG = "Ocorreu um erro durante o processo de mapeamento do objeto UserContract para UserEntity. Detalhes do erro: {}";
 
     /**
      * Este método é usado para mapear um objeto de origem do tipo {@link User} para um objeto de entidade {@link UserEntity}.
@@ -49,6 +52,7 @@ public class UserEntityMapper implements MapperStrategy<UserEntity, UserContract
             userEntity = BuilderMapper.mapTo(UserEntity.class, source);
             userEntity.setUserProfile(Enum.valueOf(UserProfileType.class, source.getUserProfile().name()));
         } catch (RuntimeException e) {
+            log.error(MAPPING_ERROR_LOG, e.getMessage(), e);
             throw new UserEntityFailuresException(MapperFailureException.ERROR.formatErrorMessage(USER_CLASS.getSimpleName()), e);
         }
         return userEntity;

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/UserMapper.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/UserMapper.java
@@ -8,6 +8,7 @@ import diegosneves.github.conectardoacoes.core.domain.user.entity.UserContract;
 import diegosneves.github.conectardoacoes.core.domain.user.entity.value.UserProfile;
 import diegosneves.github.conectardoacoes.core.exception.UserCreationFailureException;
 import diegosneves.github.conectardoacoes.core.utils.ValidationUtils;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Implementação da interface {@link MapperStrategy} para a conversão entre a entidade {@link UserEntity} e a classe de domínio {@link User}.
@@ -22,9 +23,11 @@ import diegosneves.github.conectardoacoes.core.utils.ValidationUtils;
  * @see MapperStrategy
  * @since 1.0.0
  */
+@Slf4j
 public class UserMapper implements MapperStrategy<UserContract, UserEntity> {
 
     public static final Class<UserEntity> USER_ENTITY_CLASS = UserEntity.class;
+    public static final String MAPPING_ERROR_LOG = "Ocorreu um erro durante o processo de mapeamento do objeto UserEntity para UserContract. Detalhes do erro: {}";
 
     /**
      * Mapeia uma entidade de usuário ({@link UserEntity}) para um objeto de usuário de domínio ({@link User}).
@@ -50,6 +53,7 @@ public class UserMapper implements MapperStrategy<UserContract, UserEntity> {
                     Enum.valueOf(UserProfile.class, source.getUserProfile().name()),
                     source.getUserPassword());
         } catch (UserCreationFailureException e) {
+            log.error(MAPPING_ERROR_LOG, e.getMessage(), e);
             throw new UserEntityFailuresException(MapperFailureException.ERROR.formatErrorMessage(USER_ENTITY_CLASS.getSimpleName()), e);
         }
         return mappedUser;

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/AddressEntityServiceImpl.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/AddressEntityServiceImpl.java
@@ -11,6 +11,7 @@ import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Addre
 import diegosneves.github.conectardoacoes.core.domain.shelter.factory.AddressFactory;
 import diegosneves.github.conectardoacoes.core.exception.AddressCreationFailureException;
 import diegosneves.github.conectardoacoes.core.utils.ValidationUtils;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 /**
@@ -39,10 +40,15 @@ import org.springframework.stereotype.Service;
  * @since 1.1.0
  */
 @Service
+@Slf4j
 public class AddressEntityServiceImpl implements AddressEntityService {
 
     public static final String ADDRESS_CREATION_ERROR = "Erro na criação do endereço. Confirme se todos os campos do endereço estão corretos e tente novamente.";
     public static final String ERROR_MAPPING_ADDRESS = "Erro durante o mapeamento do endereço para persistência";
+
+    public static final String CREATION_FAILURE_LOG = "Falha na tentativa de criação de um novo Endereço. Causa do erro: {}";
+    public static final String ADDRESS_MAPPING_ERROR_LOG = "Ocorreu uma falha ao tentar mapear o Endereço. Causa do erro: {}";
+    public static final String ADDRESS_REGISTRATION_SUCCESS_LOG = "Novo endereço registrado com êxito! Identificador do endereço (ID): {} - Código Postal (ZIPCODE): {}";
 
 
     private final AddressRepository repository;
@@ -58,6 +64,7 @@ public class AddressEntityServiceImpl implements AddressEntityService {
         try {
             newAddress = AddressFactory.create(address.getStreet(), address.getNumber(), address.getNeighborhood(), address.getCity(), address.getState(), address.getZip());
         } catch (AddressCreationFailureException e) {
+            log.error(CREATION_FAILURE_LOG, e.getMessage(), e);
             throw new AddressEntityFailuresException(ADDRESS_CREATION_ERROR, e);
         }
         this.mapAddressAndSaveToRepository(newAddress);
@@ -77,9 +84,11 @@ public class AddressEntityServiceImpl implements AddressEntityService {
         try {
             addressEntity = BuilderMapper.mapTo(new AddressEntityMapper(), address);
         } catch (RuntimeException e) {
+            log.error(ADDRESS_MAPPING_ERROR_LOG, e.getMessage(), e);
             throw new AddressEntityFailuresException(ERROR_MAPPING_ADDRESS, e);
         }
         this.repository.save(addressEntity);
+        log.info(ADDRESS_REGISTRATION_SUCCESS_LOG, address.getId(), address.getZip());
     }
 
 }

--- a/src/main/java/diegosneves/github/conectardoacoes/core/utils/ValidationUtils.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/core/utils/ValidationUtils.java
@@ -1,6 +1,7 @@
 package diegosneves.github.conectardoacoes.core.utils;
 
 import diegosneves.github.conectardoacoes.core.exception.ValidationUtilsException;
+import lombok.extern.slf4j.Slf4j;
 
 import java.lang.reflect.Constructor;
 
@@ -11,6 +12,7 @@ import java.lang.reflect.Constructor;
  * @author diegoneves
  * @since 1.0.0
  */
+@Slf4j
 public class ValidationUtils {
 
     private ValidationUtils() {
@@ -43,8 +45,11 @@ public class ValidationUtils {
     private static void throwException(String message, Class<? extends RuntimeException> runtimeExceptionClass) {
         try {
             Constructor<? extends RuntimeException> exceptionConstructor = runtimeExceptionClass.getConstructor(String.class);
-            throw exceptionConstructor.newInstance(message);
+            var exception = exceptionConstructor.newInstance(message);
+            log.error(message, exception);
+            throw exception;
         } catch (ReflectiveOperationException e) {
+            log.error(runtimeExceptionClass.getSimpleName(), e);
             throw new ValidationUtilsException(runtimeExceptionClass.getSimpleName(), e);
         }
     }


### PR DESCRIPTION
# Solicitação de Pull Request

## Status

- [x] In Progress
- [x] Ready to Merging

## Tipo

- [ ] Release
- [x] Feature
- [ ] Technical Debt
- [ ] Fix
- [ ] Test
- [ ] Refactor
- [ ] Documentation
- [ ] Performance

## Descrição

**Commit** 015a7e5eda4e0c3ee5b716ecf044934c9c5acb1c:

Neste commit, uma seção de Javadoc foi adicionada ao arquivo README. A nova seção fornece um link para a documentação detalhada do Javadoc, permitindo que os usuários acessem mais facilmente essa documentação.

**Arquivo alterado:** `README.md`

**Alterações:**

- Adicionado um novo item ao índice do README.
- Inclusão de uma nova seção de Javadoc no README, com um link para a documentação gerada pelo Javadoc.

**Nota:** A essência deste commit é oferecer uma referência acessível à documentação do Javadoc através da inclusão deste link diretamente no arquivo README.

---

**Commit** caafb80de0e0f487d9a21a3a75535befe56f04cc:

Este commit adiciona registros de log em vários serviços e utilitários no pacote. Isso inclui a classe ValidationUtils, bem como os serviços de endereço, usuário e abrigo. Além disso, as mensagens de log foram adicionadas em vários pontos para indicar o sucesso ou falha de eventos específicos. Assim, melhorando a capacidade de rastreabilidade e debug das operações.

**Arquivos Alterados:** `AddressEntityServiceImpl.java`, `ShelterEntityServiceImpl.java`, `UserEntityServiceImpl.java`, `ValidationUtils.java`

**Alterações:**

- A anotação `@Slf4j` foi adicionada nas classes `AddressEntityServiceImpl.java`, `ShelterEntityServiceImpl.java`, `UserEntityServiceImpl.java` e `ValidationUtils.java` para habilitar o registro de log.
- Mensagens de log foram adicionadas em vários blocos `catch` para registrar situações de erro. Mensagens de sucesso também foram adicionadas em determinados pontos-chave, como após a criação de um novo endereço ou abrigo, para registrar a realização bem-sucedida dessas operações.

**Nota:** A principal ênfase deste commit é melhorar a rastreabilidade das operações por meio do registro de log. Isso facilitará a identificação e a resolução de problemas, aumentando assim a qualidade do código.

---

**Commit** 46f2bc3884920f138e12e31ef86519646394a480:

Este commit aprimora o rastreamento ao integrar logs de erro em várias classes mappers (`AddressMapper`, `ShelterEntityMapper`, `UserMapper`, etc). Isso aprimora a capacidade de rastrear os processos de mapeamento, facilitando a identificação de problemas e promovendo melhorias na depuração e manutenção do código.

**Arquivos Alterados:** `AddressMapper.java`, `DonationMapper.java`, `ShelterEntityMapper.java`, `ShelterMapper.java`, `UserEntityMapper.java`, `UserMapper.java`.

**Alterações:**

- Logs de erro foram adicionados em todas as classes mappers. Isso inclui a captura e log de erros ao mapear de entidades para objetos e vice-versa.

**Notas:**

Este commit foca em melhorar a capacidade de rastreamento de erros durante os processos de mapeamento, o que facilita a identificação de problemas e a depuração. Cada classe mapper agora gera um log quando ocorre um erro durante o mapeamento, fornecendo detalhes sobre o erro para auxiliar na resolução de problemas.

---

**Commit** 72b5c5fa03e4879ee0e1e9e29c6c1e582493aab8:

Este commit adiciona um manipulador de exceção para erros de leitura de mensagens HTTP no manipulador de exceções global (ControllerExceptionHandler). Esse tipo de erro ocorre quando há uma falha de sintaxe no corpo de uma solicitação HTTP. Agora, quando essa exceção é lançada, uma mensagem de erro é registrada no log e uma resposta BAD_REQUEST (400) é retornada ao cliente, indicando que a solicitação era inválida ou não pôde ser entendida pelo servidor.

**Arquivos Alterados:** `ControllerExceptionHandler.java`

**Alterações:**

- Adicionado um novo método para lidar com erros do tipo HttpMessageNotReadableException em `ControllerExceptionHandler`.
- Agora, a exceção registra uma mensagem de erro no log.
- Retorna uma resposta BAD_REQUEST (400) ao cliente quando ocorre essa exceção.

**Nota:** Este commit foca em melhorar a manipulação de erros relacionados a falhas de sintaxe no corpo de uma solicitação HTTP, fornecendo uma resposta apropriada para o cliente e registrando o erro para futuras análises.

