### PR TITLE
feat/i60 :sparkles:  [REST] - Alteração nas Mensagens de Erro da API para Torná-las Mais Amigáveis

### DIFF
--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/config/handler/ControllerExceptionHandler.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/config/handler/ControllerExceptionHandler.java
@@ -1,13 +1,7 @@
 package diegosneves.github.conectardoacoes.adapters.rest.config.handler;
 
 import diegosneves.github.conectardoacoes.adapters.rest.dto.ExceptionDTO;
-import diegosneves.github.conectardoacoes.adapters.rest.exception.AddressEntityFailuresException;
-import diegosneves.github.conectardoacoes.adapters.rest.exception.ConstructorDefaultUndefinedException;
-import diegosneves.github.conectardoacoes.adapters.rest.exception.DonationEntityFailuresException;
-import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
-import diegosneves.github.conectardoacoes.adapters.rest.exception.ShelterEntityFailuresException;
-import diegosneves.github.conectardoacoes.adapters.rest.exception.UserEntityFailuresException;
-import diegosneves.github.conectardoacoes.adapters.rest.model.UserEntity;
+import diegosneves.github.conectardoacoes.adapters.rest.exception.CustomException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -59,127 +53,26 @@ public class ControllerExceptionHandler {
     }
 
     /**
-     * Método que manipula as exceções específicas da {@link ConstructorDefaultUndefinedException}
-     * que podem ocorrer ao instanciar objetos sem um construtor padrão. Quando essa exceção
-     * é lançada, este método a capturará e retornará uma resposta HTTP adequada usando
-     * o {@link ExceptionDTO} para transmitir as informações da exceção.
-     * <p>
-     * Este método é anotado com {@code @ExceptionHandler}, que é uma anotação Springer,
-     * significando que o Springer invocará automaticamente este método para tratar as exceções do
-     * tipo {@link ConstructorDefaultUndefinedException} lançadas por qualquer método do controlador
-     * respectivo.
+     * Trata as exceções do tipo {@link CustomException}. Este método atua como um tratador de exceptions
+     * para a {@link CustomException} usada na camada de serviço. Quando uma {@link CustomException} é lançada,
+     * este método captura a exceção e a processa criando uma {@link ExceptionDTO}, e um
+     * {@link ResponseEntity} com os detalhes de erro da exceção.
      *
-     * @param exception A exceção específica do {@link ConstructorDefaultUndefinedException} que ocorreu.
-     * @return Uma resposta HTTP encapsulada em uma {@link ResponseEntity} que contém o DTO da exceção,
-     * composto pela mensagem da exceção e um código de status HTTP. O status HTTP da resposta é
-     * o mesmo que o status HTTP da exceção.
+     * @param exception a instância de CustomException que foi lançada e precisa ser tratada. Este
+     *                  parâmetro carrega detalhes essenciais sobre o que deu errado
+     *                  durante a execução do programa para o cliente.
+     * @return um objeto ResponseEntity contendo o código de status e corpo que deve ser
+     * enviado como resposta após capturar uma {@link CustomException}. O corpo da resposta
+     * inclui uma mensagem e o valor do código de status da CustomException
+     * enquanto o código de status da resposta é configurado como o código de status HTTP
+     * dos detalhes do erro da exceção.
+     * @throws CustomException processado por este método. Geralmente contém
+     *                         informações necessárias para o cliente ou os desenvolvedores identificarem o que deu errado durante a execução.
      */
-    @ExceptionHandler(ConstructorDefaultUndefinedException.class)
-    public ResponseEntity<ExceptionDTO> handleMapperFailures(ConstructorDefaultUndefinedException exception) {
-        ExceptionDTO dto = new ExceptionDTO(exception.getMessage(), ConstructorDefaultUndefinedException.ERROR.getStatusCodeValue());
-        return ResponseEntity.status(ConstructorDefaultUndefinedException.ERROR.getHttpStatusCode()).body(dto);
-    }
-
-    /**
-     * Manipula as exceções específicas de {@link ShelterEntityFailuresException} que
-     * podem ocorrer durante a manipulação dos dados da entidade de abrigo. Quando uma dessas exceções
-     * é lançada, este método irá capturá-la e retornar uma resposta adequada usando o {@link ExceptionDTO}
-     * para transportar as informações de exceção.
-     * <p>
-     * O método é anotado com {@code @ExceptionHandler}, o que significa que será invocado automaticamente
-     * pelo Spring para tratar exceções do tipo {@link ShelterEntityFailuresException} lançadas
-     * por qualquer método do respectivo controlador.
-     *
-     * @param exception A exceção específica do {@link ShelterEntityFailuresException} que ocorreu.
-     * @return Uma resposta HTTP representada como {@link ResponseEntity} contendo o DTO de exceção
-     * que contém a mensagem da exceção e um código de status HTTP. O status HTTP da resposta será
-     * o mesmo que o status HTTP da exceção.
-     */
-    @ExceptionHandler(ShelterEntityFailuresException.class)
-    public ResponseEntity<ExceptionDTO> handleShelterEntityFailures(ShelterEntityFailuresException exception) {
-        ExceptionDTO dto = new ExceptionDTO(exception.getMessage(), ShelterEntityFailuresException.ERROR.getStatusCodeValue());
-        return ResponseEntity.status(ShelterEntityFailuresException.ERROR.getHttpStatusCode()).body(dto);
-    }
-
-    /**
-     * Manipula as exceções específicas de {@link AddressEntityFailuresException} que
-     * podem ocorrer durante a manipulação dos dados da entidade de endereço. Quando uma dessas exceções
-     * é lançada, esse método irá capturá-la e retornar uma resposta adequada usando o {@link ExceptionDTO}
-     * para transportar as informações de exceção.
-     * <p>
-     * O método é anotado com {@code @ExceptionHandler}, o que significa que será invocado automaticamente
-     * pelo Spring para tratar exceções do tipo {@link AddressEntityFailuresException} lançadas
-     * por qualquer método do respectivo controlador.
-     *
-     * @param exception A exceção específica do {@link AddressEntityFailuresException} que ocorreu.
-     * @return Uma resposta HTTP representada como {@link ResponseEntity} contendo o DTO de exceção
-     * que contém a mensagem da exceção e um código de status HTTP.
-     * O status HTTP da resposta será o mesmo que o status HTTP da exceção.
-     */
-    @ExceptionHandler(AddressEntityFailuresException.class)
-    public ResponseEntity<ExceptionDTO> handleAddressEntityFailures(AddressEntityFailuresException exception) {
-        ExceptionDTO dto = new ExceptionDTO(exception.getMessage(), AddressEntityFailuresException.ERROR.getStatusCodeValue());
-        return ResponseEntity.status(AddressEntityFailuresException.ERROR.getHttpStatusCode()).body(dto);
-    }
-
-    /**
-     * Manipula a exceção {@link MapperFailureException} e retorna uma resposta de erro adequada.
-     * <p>
-     * Este método é usado para tratar as exceções específicas do {@link MapperFailureException}
-     * que podem ocorrer durante a operação de mapeamento de classes. Quando uma dessas exceções é lançada,
-     * esse método irá capturá-la e retornar uma resposta adequada usando o {@link ExceptionDTO} para
-     * transportar as informações de exceção.
-     * <p>
-     * O método é anotado com {@code @ExceptionHandler}, o que significa que será invocado automaticamente
-     * pelo Spring para tratar exceções do tipo {@link MapperFailureException} lançadas por qualquer
-     * método do controlador.
-     *
-     * @param exception A exceção específica do {@link MapperFailureException} que ocorreu.
-     * @return Uma resposta HTTP representada como {@link ResponseEntity} contendo o DTO de exceção que
-     * contém a mensagem da exceção e um código de status HTTP. O status HTTP da resposta será
-     * o mesmo que o status HTTP da exceção.
-     */
-    @ExceptionHandler(MapperFailureException.class)
-    public ResponseEntity<ExceptionDTO> handleMapperFailures(MapperFailureException exception) {
-        ExceptionDTO dto = new ExceptionDTO(exception.getMessage(), MapperFailureException.ERROR.getStatusCodeValue());
-        return ResponseEntity.status(MapperFailureException.ERROR.getHttpStatusCode()).body(dto);
-    }
-
-    /**
-     * Este método é usado para manipular as exceções específicas de {@link UserEntityFailuresException}
-     * que podem ocorrer durante a manipulação dos dados do {@link UserEntity}. Quando uma dessas exceções é lançada,
-     * esse método irá capturá-la e retornar uma resposta adequada usando o {@link ExceptionDTO}
-     * para transportar as informações de exceção.
-     * <p>
-     * O método é anotado com {@code @ExceptionHandler}, o que significa que será invocado automaticamente
-     * pelo Spring para tratar exceções do tipo {@link UserEntityFailuresException} lançadas por qualquer
-     * método do controlador.
-     *
-     * @param exception A exceção específica do {@link UserEntityFailuresException} que ocorreu.
-     * @return Uma resposta HTTP representada como ResponseEntity contendo o DTO de exceção que contém a
-     * mensagem da exceção e um código de status HTTP. O status HTTP da resposta será o mesmo que
-     * o status HTTP da exceção.
-     */
-    @ExceptionHandler(UserEntityFailuresException.class)
-    public ResponseEntity<ExceptionDTO> handleUserEntityFailures(UserEntityFailuresException exception) {
-        ExceptionDTO dto = new ExceptionDTO(exception.getMessage(), UserEntityFailuresException.ERROR.getStatusCodeValue());
-        return ResponseEntity.status(UserEntityFailuresException.ERROR.getHttpStatusCode()).body(dto);
-    }
-
-    /**
-     * Manipula exceções lançadas quando há falhas com as entidades de doação.
-     *
-     * @param exception A instância da {@link DonationEntityFailuresException} lançada durante operações de entidade de doação.
-     *                  Este parâmetro já encapsula a mensagem de erro e os detalhes do erro. Normalmente, esta exceção é lançada quando uma operação realizada numa entidade de doação falha.
-     * @return Um objeto {@link ResponseEntity} contendo o corpo personalizado da resposta HTTP e o código de status.
-     * O corpo desta resposta é um objeto da classe {@link ExceptionDTO} que envolve a mensagem de erro obtida da exceção e o código de status.
-     * O código de status da resposta é derivado do erro associado com a instância do DonationEntityFailuresException.
-     * @throws DonationEntityFailuresException Se houver um erro durante o processamento de operações sobre a entidade de doação.
-     */
-    @ExceptionHandler(DonationEntityFailuresException.class)
-    public ResponseEntity<ExceptionDTO> handleDonationEntityFailures(DonationEntityFailuresException exception) {
-        ExceptionDTO dto = new ExceptionDTO(exception.getMessage(), DonationEntityFailuresException.ERROR.getStatusCodeValue());
-        return ResponseEntity.status(DonationEntityFailuresException.ERROR.getHttpStatusCode()).body(dto);
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ExceptionDTO> handleDonationEntityFailures(CustomException exception) {
+        ExceptionDTO dto = new ExceptionDTO(exception.getMessage(), exception.getErrorDetails().getStatusCodeValue());
+        return ResponseEntity.status(exception.getErrorDetails().getHttpStatusCode()).body(dto);
     }
 
 }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/controller/UserController.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/controller/UserController.java
@@ -101,14 +101,7 @@ public interface UserController {
     @Operation(
             summary = "Encontra um usuário pelo email",
             description = "Este endpoint é responsável por encontrar um Usuário no sistema pelo seu email utilizando os dados recebidos por meio de uma requisição do tipo GET",
-            tags = "Usuários",
-            parameters = {
-                    @Parameter(
-                            name = "Perfil do usuário",
-                            description = "O campo 'userProfile' só permite dois valores possíveis: 'Doador' ou 'Beneficiário'.",
-                            schema = @Schema(implementation = UserProfileType.class)
-                    )
-            }
+            tags = "Usuários"
     )
     @ApiResponses(value = {
             @ApiResponse(
@@ -117,7 +110,7 @@ public interface UserController {
                     content = @Content(schema = @Schema(implementation = UserEntityCreatedResponse.class))
             )
     })
-    public ResponseEntity<UserEntityCreatedResponse> findUserByEmail(@PathVariable("email") String email);
+    ResponseEntity<UserEntityCreatedResponse> findUserByEmail(@PathVariable("email") String email);
 
 
 }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/controller/imp/UserControllerImpl.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/controller/imp/UserControllerImpl.java
@@ -41,7 +41,7 @@ public class UserControllerImpl implements UserController {
 
     @Override
     public ResponseEntity<UserEntityCreatedResponse> findUserByEmail(String email) {
-        UserEntityCreatedResponse userByEmail = service.findUserByEmail(email);
+        UserEntityCreatedResponse userByEmail = this.service.findUserByEmail(email);
         return ResponseEntity.ok(userByEmail);
     }
 }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/enums/ExceptionDetails.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/enums/ExceptionDetails.java
@@ -1,6 +1,10 @@
 package diegosneves.github.conectardoacoes.adapters.rest.enums;
 
+import diegosneves.github.conectardoacoes.adapters.rest.exception.DetailsFailureException;
 import org.springframework.http.HttpStatus;
+
+import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * A classe {@link ExceptionDetails} é uma enumeração que define várias mensagens de exceções.
@@ -12,18 +16,39 @@ import org.springframework.http.HttpStatus;
  */
 public enum ExceptionDetails {
 
-    CONSTRUCTOR_DEFAULT_UNDEFINED("Classe [ %s ] deve declarar um construtor padrão.", HttpStatus.NOT_IMPLEMENTED),
-    CLASS_MAPPING_FAILURE("Falha ao tentar mapear a classe [ %s ].", HttpStatus.BAD_REQUEST),
-    SHELTER_OPERATION_FAILURE("Ocorreu um erro ao realizar uma operação no Abrigo. Motivo: %s", HttpStatus.BAD_REQUEST),
-    DONATION_OPERATION_FAILURE("Ocorreu um erro ao registrar uma doação. Motivo: %s", HttpStatus.BAD_REQUEST),
-    ADDRESS_OPERATION_FAILURE("Ocorreu um erro ao realizar uma operação no Endereço. Motivo: %s", HttpStatus.BAD_REQUEST),
-    USER_OPERATION_FAILURE("Ocorreu um erro ao realizar uma operação com o Usuário. Motivo: %s", HttpStatus.BAD_REQUEST),
-    INVALID_UUID_FORMAT_MESSAGE("O ID %s precisa estar no formato UUID", HttpStatus.INTERNAL_SERVER_ERROR);
+    TERM_NOT_FOUND(1, "Desconhecido", HttpStatus.NOT_IMPLEMENTED),
+    CONSTRUCTOR_DEFAULT_UNDEFINED(2, "Classe [ %s ] deve declarar um construtor padrão.", HttpStatus.NOT_IMPLEMENTED),
+    REQUEST_VALIDATION_ERROR_MESSAGE(3, "Por favor, forneça uma requisição de criação de Abrigo preenchida corretamente.", HttpStatus.BAD_REQUEST),
+    CLASS_MAPPING_FAILURE(4, "Falha ao tentar mapear a classe [ %s ].", HttpStatus.BAD_REQUEST),
+    SHELTER_CREATION_ERROR_MESSAGE(5, "Erro na criação do Abrigo. Confirme se todos os campos do Abrigo estão corretos e tente novamente.", HttpStatus.BAD_REQUEST),
+    INVALID_UUID_FORMAT_MESSAGE(6, "O ID %s precisa estar no formato UUID", HttpStatus.BAD_REQUEST),
+    RESPONSIBLE_USER_PROFILE_INVALID(7, "O usuário deve possuir o perfil de responsável.", HttpStatus.BAD_REQUEST),
+    EMAIL_NOT_FOUND_ERROR_MESSAGE(8, "Não foi possivel encontrar um usuário com o email %s .", HttpStatus.BAD_REQUEST),
+    RESPONSIBLE_USER_ALREADY_IN_USE(9, "Este usuário já possui responsabilidade sobre outro abrigo.", HttpStatus.BAD_REQUEST),
+    EMAIL_ALREADY_IN_USE(10, "Desculpe, o endereço de email %s já está associado a uma conta existente. Por favor, tente com um email diferente.", HttpStatus.BAD_REQUEST),
+    USER_RESPONSIBLE_EMAIL_NOT_FOUND_ERROR(11, "Ops! Não conseguimos encontrar o e-mail do usuário responsável. Por gentileza, tente novamente.", HttpStatus.BAD_REQUEST),
+    DONATION_VALIDATION_ERROR(13, "Para o cadastro de doações, é indispensável fornecer informações válidas e completas.", HttpStatus.BAD_REQUEST),
+    EMPTY_DONATION_LIST(15, "Até o momento, não há doações listadas.", HttpStatus.BAD_REQUEST),
+    RESPONSIBLE_EMAIL_NOT_ASSOCIATED_WITH_SHELTER(17, "Por favor, verifique se o e-mail do usuário responsável está correto e associado a um abrigo. Caso contrário, certifique-se de que o usuário responsável tenha um e-mail válido em nosso sistema.", HttpStatus.BAD_REQUEST),
+    INVALID_ID_MESSAGE(19, "Deve ser fornecido um ID válido!", HttpStatus.BAD_REQUEST),
+    SHELTER_ERROR_MESSAGE(21, "Um objeto Abrigo válido deve ser fornecido para persistência!", HttpStatus.BAD_REQUEST),
+    ADDRESS_CREATION_ERROR(23, "Erro na criação do endereço. Confirme se todos os campos do endereço estão corretos e tente novamente.", HttpStatus.BAD_REQUEST),
+    ERROR_MAPPING_ADDRESS(25, "Erro durante o mapeamento do endereço para persistência", HttpStatus.BAD_REQUEST),
+    MISSING_USER_ENTITY_REQUEST_ERROR_MESSAGE(27, "Por favor, forneça uma requisição de criação de usuário preenchida corretamente.", HttpStatus.BAD_REQUEST),
+    INVALID_EMAIL_ERROR_MESSAGE(29, "Não foi informado nenhum email. Por favor, forneça um email válido.", HttpStatus.BAD_REQUEST),
+    USER_CREATION_FAILURE_MESSAGE(31, "Ops! A criação do novo usuário não foi bem-sucedida. Por favor, certifique-se de que seus dados estão corretos e tente novamente.", HttpStatus.BAD_REQUEST),
+    USER_PROFILE_VALIDATION_FAILURE(33, "A validação do Perfil do usuário fornecido falhou.", HttpStatus.BAD_REQUEST),
+    REQUIRED_USER_ERROR_MESSAGE(35, "Um usuário válido é requerido para efetuar a persistência.", HttpStatus.BAD_REQUEST);
 
+
+    public static final String EXCEPTION_PREFIX = "T%03dF - ";
+
+    private final Integer term;
     private final String message;
     private final HttpStatus httpStatus;
 
-    ExceptionDetails(String message, HttpStatus httpStatus) {
+    ExceptionDetails(Integer term, String message, HttpStatus httpStatus) {
+        this.term = term;
         this.message = message;
         this.httpStatus = httpStatus;
     }
@@ -36,8 +61,23 @@ public enum ExceptionDetails {
      * @return A mensagem após a formatação.
      */
     public String formatErrorMessage(String message) {
-        return String.format(this.message, message);
+        return String.format(EXCEPTION_PREFIX, this.term) + String.format(this.message, message);
     }
+
+    /**
+     * Método responsável por formatar uma mensagem de erro.
+     * <p>
+     * Esse método forma uma mensagem de erro por prefixar a string de termo com um prefixo de exceção definido e
+     * em seguida, concatenando a mensagem. Isso é típico de cenários onde você precisa gerar mensagens de erro
+     * personalizadas para exceções.
+     *
+     * @return a mensagem de erro formatada como uma string. A mensagem de erro retornada consiste no termo prefixado
+     * com o EXCEPTION_PREFIX seguido pela mensagem de erro original.
+     */
+    public String formatErrorMessage() {
+        return String.format(EXCEPTION_PREFIX, this.term) + this.message;
+    }
+
 
     /**
      * Retorna o código de status HTTP associado ao erro.
@@ -55,6 +95,31 @@ public enum ExceptionDetails {
      */
     public HttpStatus getHttpStatusCode() {
         return this.httpStatus;
+    }
+
+    /**
+     * Obtem os detalhes da exceção pelo código correspondente.
+     *
+     * <p> Este método percorre o enum ExceptionDetails, procura um elemento cujo campo 'term' seja igual
+     * ao código de entrada e retorna esse elemento. Se nenhum elemento for encontrado com o código
+     * fornecido, uma nova exceção DetailsFailureException é lançada com código de erro 1.
+     *
+     * <h2> Exemplo de Uso </h2>
+     * {@code ExceptionDetails detail = getExceptionDetails(1001);}
+     *
+     * <h2> Exceções Lançadas </h2>
+     * {@code DetailsFailureException} - Se o código fornecido não corresponder a nenhum 'term'
+     * do enum ExceptionDetails
+     *
+     * @param code é um Integer representando o código do term correspondente à exceção a ser buscada.
+     * @return Retorna o detalhe da exceção correspondente ao código.
+     * @throws DetailsFailureException se nenhum detalhe de exceção correspondente for encontrado.
+     */
+    public static ExceptionDetails getExceptionDetails(Integer code) {
+        return Arrays.stream(ExceptionDetails.values())
+                .filter(detail -> Objects.equals(detail.term, code))
+                .findFirst()
+                .orElseThrow(() -> new DetailsFailureException(1));
     }
 
 }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/AddressEntityFailuresException.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/AddressEntityFailuresException.java
@@ -8,37 +8,73 @@ import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
  * relacionada a uma entidade de endereço, como mapeamento ou validação.
  * <p>
  * As mensagens de erro personalizadas para esta exceção são definidas através das constantes na enumeração
- * {@link ExceptionDetails}. A mensagem de erro específica usada neste caso é a
- * {@link ExceptionDetails#ADDRESS_OPERATION_FAILURE}.
+ * {@link ExceptionDetails}.
  * <p>
  * Sendo uma {@link RuntimeException}, não é obrigatório que seja declarada na cláusula `throws` dos métodos
  * que a lançam, e ela não precisa ser capturada explicitamente.
  * <p>
+ *
  * @author diegoneves
- * @since 1.0.0
  * @see RuntimeException
+ * @since 1.0.0
  */
-public class AddressEntityFailuresException extends RuntimeException {
+public class AddressEntityFailuresException extends CustomException {
 
-    public static final ExceptionDetails ERROR = ExceptionDetails.ADDRESS_OPERATION_FAILURE;
+    /**
+     * Este é um construtor da classe {@link AddressEntityFailuresException}.
+     * <p>
+     * Cria uma instância de {@link AddressEntityFailuresException} com uma mensagem de erro personalizada,
+     * determinada a partir do código de erro fornecido no parâmetro term.
+     * O código de erro é usado para buscar na enumeração {@link ExceptionDetails} a mensagem da exceção correspondente.
+     * Após a recuperação, a mensagem é então passada para o construtor da superclasse {@link RuntimeException} através da chamada super().
+     * <p>
+     * Se nenhuma mensagem de erro corresponder ao código fornecido, uma exceção do tipo {@link DetailsFailureException} será lançada.
+     *
+     * @param term o código de erro que identifica a mensagem a ser usada para esta exceção. Deve corresponder a uma das
+     *             constantes definidas na enumeração {@link ExceptionDetails}.
+     * @throws DetailsFailureException Se o termo fornecido não corresponder a nenhuma das constantes em {@link ExceptionDetails}.
+     * @see RuntimeException
+     * @see ExceptionDetails
+     */
+    public AddressEntityFailuresException(Integer term) {
+        super(obtainExceptionDetails(term));
+    }
 
     /**
      * Este construtor para a classe {@link AddressEntityFailuresException} recebe uma string
      * que representa uma mensagem personalizada de erro. A mensagem fornecida é então formatada
      * por meio do método {@code ERROR.formatErrorMessage(message)}, onde {@code ERROR} é uma
-     * constante da enumeração {@link ExceptionDetails}, especificamente
-     * {@link ExceptionDetails#ADDRESS_OPERATION_FAILURE}, que guarda detalhes para uma operação
-     * de endereço que falhou.
+     * constante da enumeração {@link ExceptionDetails}.
      * <p>
      * A mensagem formatada é então passada para o construtor da superclasse {@link RuntimeException}
      * através da chamada {@code super()}.
-     * <p>
+     *
      * @param message A mensagem personalizada de erro que será formatada e passada
      *                para a superclasse {@link RuntimeException}.
-     * @throws NullPointerException se a mensagem fornecida for {@code null}.
      */
-    public AddressEntityFailuresException(String message) {
-        super(ERROR.formatErrorMessage(message));
+    public AddressEntityFailuresException(Integer term, String message) {
+        super(message, obtainExceptionDetails(term));
+    }
+
+    /**
+     * Construtor da classe {@link AddressEntityFailuresException}.
+     * <p>
+     * Este construtor utiliza um inteiro genérico 'term' e uma instância da classe {@link Throwable} 'cause'.
+     * As informações de 'term' são utilizadas para obtenção dos detalhes da exceção através do método
+     * {@link #obtainExceptionDetails(Integer)}. Em seguida, o construtor invoca o construtor da superclasse
+     * {@link CustomException} com 'cause' e os detalhes da exceção obtidos anteriormente.
+     *
+     * @param term  O código de erro usado para buscar na enumeração {@link ExceptionDetails} a mensagem correspondente à exceção.
+     *              Se o 'term' fornecido não corresponder a nenhuma das constantes em {@link ExceptionDetails}, este construtor
+     *              lançará uma exceção do tipo {@link DetailsFailureException}.
+     * @param cause A causa raiz que causou a exceção. Isto é útil para rastrear e registrar a exceção que desencadeou esta exceção.
+     * @throws DetailsFailureException Se o 'term' fornecido não corresponder a nenhuma das constantes em {@link ExceptionDetails}.
+     * @see Throwable
+     * @see CustomException
+     * @see ExceptionDetails
+     */
+    public AddressEntityFailuresException(Integer term, Throwable cause) {
+        super(cause, obtainExceptionDetails(term));
     }
 
     /**
@@ -50,7 +86,7 @@ public class AddressEntityFailuresException extends RuntimeException {
      * @param message A mensagem de erro personalizada.
      * @param cause   A exceção causal.
      */
-    public AddressEntityFailuresException(String message, Throwable cause) {
-        super(ERROR.formatErrorMessage(message), cause);
+    public AddressEntityFailuresException(Integer term, String message, Throwable cause) {
+        super(message, cause, obtainExceptionDetails(term));
     }
 }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/ConstructorDefaultUndefinedException.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/ConstructorDefaultUndefinedException.java
@@ -1,7 +1,5 @@
 package diegosneves.github.conectardoacoes.adapters.rest.exception;
 
-import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
-
 /**
  * Exceção personalizada que é lançada quando não é definido um construtor padrão.
  *
@@ -9,17 +7,15 @@ import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
  * @author diegoneves
  * @since 1.0.0
  */
-public class ConstructorDefaultUndefinedException extends RuntimeException {
-
-    public static final ExceptionDetails ERROR = ExceptionDetails.CONSTRUCTOR_DEFAULT_UNDEFINED;
+public class ConstructorDefaultUndefinedException extends CustomException {
 
     /**
      * Construtor da exceção {@link ConstructorDefaultUndefinedException}.
      *
      * @param message a mensagem de detalhe da exceção.
      */
-    public ConstructorDefaultUndefinedException(String message) {
-        super(ERROR.formatErrorMessage(message));
+    public ConstructorDefaultUndefinedException(Integer term, String message) {
+        super(message, obtainExceptionDetails(term));
     }
 
     /**
@@ -28,8 +24,8 @@ public class ConstructorDefaultUndefinedException extends RuntimeException {
      * @param message a mensagem de detalhe da exceção.
      * @param e a causa da exceção.
      */
-    public ConstructorDefaultUndefinedException(String message, Throwable e) {
-        super(ERROR.formatErrorMessage(message), e);
+    public ConstructorDefaultUndefinedException(Integer term, String message, Throwable e) {
+        super(message, e, obtainExceptionDetails(term));
     }
 
 }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/CustomException.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/CustomException.java
@@ -1,0 +1,68 @@
+package diegosneves.github.conectardoacoes.adapters.rest.exception;
+
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
+
+/**
+ * Classe abstrata CustomException que estende a classe RuntimeException.
+ * Esta classe é designada para lidar com exceções personalizadas no aplicativo.
+ *
+ * <p>A classe contém um objeto estático de {@code ExectionDetails} que pode ser usado para fornecer
+ * detalhes adicionais sobre a exceção. As exceções podem ser construídas com uma mensagem de erro específica e/ou com
+ * uma causa raiz, permitindo o rastreamento do erro com mais facilidade.
+ *
+ * <p>A classe também fornece um método estático para obter detalhes excepcionais com base em termos de exceção {@code Integer}.
+ *
+ * <p> É importante destacar que esta classe é abstrata e deve ser estendida para uso e para casos de exceção personalizados.
+ *
+ * @author diegoneves
+ * @since 1.1.0
+ */
+public abstract class CustomException extends RuntimeException {
+
+    private final ExceptionDetails errorDetails;
+
+    protected CustomException(ExceptionDetails error) {
+        super(error.formatErrorMessage());
+        this.errorDetails = error;
+    }
+
+    protected CustomException(String message, ExceptionDetails error) {
+        super(error.formatErrorMessage(message));
+        this.errorDetails = error;
+    }
+
+    protected CustomException(Throwable cause, ExceptionDetails error) {
+        super(error.formatErrorMessage(), cause);
+        this.errorDetails = error;
+    }
+
+    protected CustomException(String message, Throwable cause, ExceptionDetails error) {
+        super(error.formatErrorMessage(message), cause);
+        this.errorDetails = error;
+    }
+
+    public ExceptionDetails getErrorDetails() {
+        return this.errorDetails;
+    }
+
+    /**
+     * Método que busca os detalhes de uma exceção na enumeração {@link ExceptionDetails}.
+     * <p>
+     * Este método retorna uma instância de {@link ExceptionDetails} com base no termo fornecido. O termo representa
+     * a chave do erro que queremos recuperar. O método faz uso do método
+     * {@link ExceptionDetails#getExceptionDetails(Integer)} para obter a instância de {@link ExceptionDetails}.
+     * Se nenhuma instância for encontrada para o termo fornecido, o método {@link ExceptionDetails#getExceptionDetails(Integer)}
+     * lançará uma exceção do tipo {@link DetailsFailureException}.
+     * <p>
+     * Este método é utilizado para fornecer detalhes sobre uma exceção específica, como a mensagem de erro,
+     * o {@code HttpStatus} associado ao erro e etc.
+     *
+     * @param term um número inteiro representando a chave do erro na enumeração {@link ExceptionDetails}.
+     * @return uma instância de {@link ExceptionDetails} representando os detalhes da exceção,
+     * incluindo a mensagem de erro e o status HTTP associado ao erro.
+     * @throws DetailsFailureException se nenhum elemento da enumeração corresponder ao termo fornecido.
+     */
+    protected static ExceptionDetails obtainExceptionDetails(Integer term) {
+        return ExceptionDetails.getExceptionDetails(term);
+    }
+}

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/CustomException.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/CustomException.java
@@ -21,26 +21,86 @@ public abstract class CustomException extends RuntimeException {
 
     private final ExceptionDetails errorDetails;
 
+    /**
+     * Este é um construtor protegido usado para criar uma nova instância de {@link CustomException} com um objeto {@link ExceptionDetails} especificado.
+     * <p>
+     * O objeto ExceptionDetails fornecido encapsula informações detalhadas de erro que são usadas para formatar a mensagem de erro
+     * que é passada para a classe {@link RuntimeException} pai. O objeto {@link ExceptionDetails} também é armazenado para recuperação posterior,
+     * permitindo que os detalhes sobre o erro estejam disponíveis ao tratar a exceção.
+     *
+     * @param error o objeto {@link ExceptionDetails} que contém as informações detalhadas de erro
+     */
     protected CustomException(ExceptionDetails error) {
         super(error.formatErrorMessage());
         this.errorDetails = error;
     }
 
+    /**
+     * Este é um construtor protegido usado para criar uma nova instância de {@link CustomException}.
+     * A mensagem de erro fornecida é formatada pelo objeto {@link ExceptionDetails} e passada para
+     * o construtor superclass {@link RuntimeException}.
+     * Além disso, o objeto {@link ExceptionDetails} é armazenado para recuperação posterior.
+     *
+     * @param message A mensagem de erro personalizada.
+     * @param error   O objeto {@link ExceptionDetails} que contém as informações detalhadas do erro.
+     */
     protected CustomException(String message, ExceptionDetails error) {
         super(error.formatErrorMessage(message));
         this.errorDetails = error;
     }
 
+    /**
+     * Este é um construtor protegido utilizado para criar uma nova instância de {@link CustomException}.
+     *
+     * <p>
+     * A instância é criada com uma causa {@link Throwable} especificada e um objeto {@link ExceptionDetails} também fornecido.
+     * A mensagem de erro formatada pelo objeto {@link ExceptionDetails} e a causa são passadas para o construtor da superclasse {@link RuntimeException}.
+     * O objeto {@link ExceptionDetails} é então armazenado neste objeto {@link CustomException} para recuperação futura.
+     *
+     * @param cause a causa (que é salva para recuperação posterior por {@link Throwable#getCause()}) (A null value is permitted,
+     *              and indicates that the cause is nonexistent or unknown).
+     * @param error o objeto {@link ExceptionDetails} que contém as informações mais detalhadas do erro.
+     */
     protected CustomException(Throwable cause, ExceptionDetails error) {
         super(error.formatErrorMessage(), cause);
         this.errorDetails = error;
     }
 
+    /**
+     * Construtor protegido para criar uma nova instância de {@link CustomException}.
+     * <p>
+     * Este construtor constrói o {@link CustomException} com uma mensagem personalizada de erro,
+     * uma causa (representada por um objeto {@link Throwable}) e um objeto detalhado da exceção
+     * (representado por um objeto {@link ExceptionDetails}).
+     * <p>
+     * A mensagem de erro é formatada pelo objeto {@link ExceptionDetails} e a causa são passadas
+     * para o construtor da superclasse {@link RuntimeException}. O objeto {@link ExceptionDetails}
+     * é armazenado dentro do objeto {@link CustomException} criado para a utilização futura.
+     *
+     * @param message A mensagem customizada de erro.
+     * @param cause   A causa do erro para fins de debug, representada por um objeto {@link Throwable}.
+     *                Um valor nulo é permitido, e indica que a causa é inexistente ou desconhecida.
+     * @param error   O objeto {@link ExceptionDetails} que contém as informações mais detalhadas do erro.
+     */
     protected CustomException(String message, Throwable cause, ExceptionDetails error) {
         super(error.formatErrorMessage(message), cause);
         this.errorDetails = error;
     }
 
+    /**
+     * Método getter para recuperar os detalhes do erro associados a esta {@link CustomException}.
+     *
+     * <p>
+     * Este método é usado para recuperar a instância de {@link ExceptionDetails} que foi fornecida
+     * ao construir esta {@link CustomException}. O objeto {@link ExceptionDetails} encapsula
+     * informações detalhadas sobre o erro que causou esta exceção, tais como a mensagem de erro e
+     * quaisquer outros dados relevantes relativos ao erro.
+     * </p>
+     *
+     * @return o objeto {@link ExceptionDetails} que encapsula as informações detalhadas sobre o
+     * erro que causou esta exceção. Isto pode ser nulo se nenhum detalhe foi fornecido quando a
+     * exceção foi construída.
+     */
     public ExceptionDetails getErrorDetails() {
         return this.errorDetails;
     }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/DetailsFailureException.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/DetailsFailureException.java
@@ -1,0 +1,46 @@
+package diegosneves.github.conectardoacoes.adapters.rest.exception;
+
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
+
+/**
+ * Esta é a classe {@link DetailsFailureException}, que estende a classe {@link CustomException}.
+ * É utilizada para lidar com exceções de detalhamento de falhas específicas.
+ * <p>
+ * Quando ocorre uma falha no detalhamento de termos, o sistema levanta esta exceção personalizada.
+ * A exceção possui duas informações principais: o termo e o código de erro.
+ * <p>
+ * O termo é o identificador principal para o qual o detalhamento falhou.
+ * O código de erro fornece mais detalhes sobre a natureza específica do erro ocorrido.
+ * <p>
+ * O construtor da classe utiliza o termo para obter os detalhes da exceção e
+ * formata a mensagem do erro com o código de erro fornecido.
+ *
+ * @author diegoneves
+ * @since 1.1.0
+ */
+public class DetailsFailureException extends CustomException {
+
+    /**
+     * Construtor para a classe {@link DetailsFailureException}.
+     * <p>
+     * Este construtor aceita um termo na forma de um inteiro, que serve como uma chave para recuperar
+     * os detalhes da exceção da enumeração {@link ExceptionDetails}. O construtor chama o método {@code super}
+     * da classe pai {@link CustomException} com os detalhes da exceção obtidos pelo termo.
+     * <p>
+     * Essa abordagem permite que os detalhes específicos da exceção, como a mensagem de erro e o status HTTP,
+     * sejam facilmente recuperados a partir do termo fornecido, fornecendo assim mais contexto sobre
+     * o motivo da falha e permitindo melhor rastreamento e resolução de erros.
+     *
+     * @param term o identificador principal para o qual o detalhamento falhou. Representa a chave do erro
+     *             na enumeração {@link ExceptionDetails}.
+     * @throws DetailsFailureException se o termo fornecido não corresponder a nenhum elemento na enumeração
+     *                                 {@link ExceptionDetails}. A exceção é lançada pelo método {@link ExceptionDetails#getExceptionDetails(Integer)}
+     *                                 que é chamado em {@link CustomException#obtainExceptionDetails(Integer)}.
+     * @see ExceptionDetails
+     * @see CustomException
+     */
+    public DetailsFailureException(Integer term) {
+        super(obtainExceptionDetails(term));
+    }
+
+}

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/DonationEntityFailuresException.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/DonationEntityFailuresException.java
@@ -1,6 +1,5 @@
 package diegosneves.github.conectardoacoes.adapters.rest.exception;
 
-import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.model.DonationEntity;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Donation;
 
@@ -14,9 +13,7 @@ import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Donat
  * @author diegoneves
  * @since 1.1.0
  */
-public class DonationEntityFailuresException extends RuntimeException {
-
-    public static final ExceptionDetails ERROR = ExceptionDetails.DONATION_OPERATION_FAILURE;
+public class DonationEntityFailuresException extends CustomException {
 
     /**
     * Uma exceção que será lançada quando ocorrer uma falha em uma operação relacionada ao {@link DonationEntity}.
@@ -24,8 +21,8 @@ public class DonationEntityFailuresException extends RuntimeException {
     *
     * @param message A mensagem específica da exceção.
     */
-    public DonationEntityFailuresException(String message) {
-        super(ERROR.formatErrorMessage(message));
+    public DonationEntityFailuresException(Integer term, String message) {
+        super(message, obtainExceptionDetails(term));
     }
 
     /**
@@ -35,8 +32,8 @@ public class DonationEntityFailuresException extends RuntimeException {
     * @param message A mensagem específica da exceção.
     * @param cause A causa original do erro.
     */
-    public DonationEntityFailuresException(String message, Throwable cause) {
-        super(ERROR.formatErrorMessage(message), cause);
+    public DonationEntityFailuresException(Integer term, String message, Throwable cause) {
+        super(message, cause, obtainExceptionDetails(term));
     }
 
 }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/MapperFailureException.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/MapperFailureException.java
@@ -1,8 +1,6 @@
 package diegosneves.github.conectardoacoes.adapters.rest.exception;
 
 
-import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
-
 /**
  * {@link MapperFailureException} é uma classe de exceção personalizada. Ela tem como finalidade gerenciar
  * falhas ocorridas durante o processo de mapeamento, e proporcionar mensagens de erro mais detalhadas.
@@ -13,9 +11,7 @@ import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
  * @author diegoneves
  * @since 1.0.0
  */
-public class MapperFailureException extends RuntimeException {
-
-    public static final ExceptionDetails ERROR = ExceptionDetails.CLASS_MAPPING_FAILURE;
+public class MapperFailureException extends CustomException {
 
     /**
      * Esta é uma classe de exceção personalizada usada para gerenciar e fornecer mensagens mais
@@ -24,8 +20,8 @@ public class MapperFailureException extends RuntimeException {
      * @param message A mensagem específica da exceção.
      * @param e       A exceção generica causada durante o mapeamento.
      */
-    public MapperFailureException(String message, Throwable e) {
-        super(ERROR.formatErrorMessage(message), e);
+    public MapperFailureException(Integer term, String message, Throwable e) {
+        super(message, e, obtainExceptionDetails(term));
     }
 
 }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/ShelterEntityFailuresException.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/ShelterEntityFailuresException.java
@@ -1,6 +1,5 @@
 package diegosneves.github.conectardoacoes.adapters.rest.exception;
 
-import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.model.ShelterEntity;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.Shelter;
 
@@ -14,9 +13,11 @@ import diegosneves.github.conectardoacoes.core.domain.shelter.entity.Shelter;
  * @author diegoneves
  * @since 1.0.0
  */
-public class ShelterEntityFailuresException extends RuntimeException {
+public class ShelterEntityFailuresException extends CustomException {
 
-    public static final ExceptionDetails ERROR = ExceptionDetails.SHELTER_OPERATION_FAILURE;
+    public ShelterEntityFailuresException(Integer term) {
+        super(obtainExceptionDetails(term));
+    }
 
     /**
     * Uma exceção que será lançada quando ocorrer uma falha em uma operação relacionada ao {@link ShelterEntity}.
@@ -24,8 +25,12 @@ public class ShelterEntityFailuresException extends RuntimeException {
     *
     * @param message A mensagem específica da exceção.
     */
-    public ShelterEntityFailuresException(String message) {
-        super(ERROR.formatErrorMessage(message));
+    public ShelterEntityFailuresException(Integer term, String message) {
+        super(message, obtainExceptionDetails(term));
+    }
+
+    public ShelterEntityFailuresException(Integer term, Throwable cause) {
+        super(cause, obtainExceptionDetails(term));
     }
 
     /**
@@ -35,8 +40,8 @@ public class ShelterEntityFailuresException extends RuntimeException {
     * @param message A mensagem específica da exceção.
     * @param cause A causa original do erro.
     */
-    public ShelterEntityFailuresException(String message, Throwable cause) {
-        super(ERROR.formatErrorMessage(message), cause);
+    public ShelterEntityFailuresException(Integer term, String message, Throwable cause) {
+        super(message, cause, obtainExceptionDetails(term));
     }
 
 }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/ShelterEntityFailuresException.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/ShelterEntityFailuresException.java
@@ -1,5 +1,6 @@
 package diegosneves.github.conectardoacoes.adapters.rest.exception;
 
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.model.ShelterEntity;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.Shelter;
 
@@ -9,37 +10,77 @@ import diegosneves.github.conectardoacoes.core.domain.shelter.entity.Shelter;
  * Herda de {@link RuntimeException} e adiciona mensagens de erro detalhadas para os erros que podem ocorrer
  * durante as operações de manipulação dos dados da entidade {@link Shelter}.
  *
- *
  * @author diegoneves
  * @since 1.0.0
  */
 public class ShelterEntityFailuresException extends CustomException {
 
+    /**
+     * O construtor da classe {@link ShelterEntityFailuresException}.
+     * <p>
+     * Este construtor recebe um termo como parâmetro, que é um número inteiro. Este termo é usado para obter os detalhes
+     * de uma exceção específica, como a mensagem de erro, o código HTTP associado ao erro, etc.
+     * <p>
+     * Este construtor faz uso do método de classe {@link #obtainExceptionDetails(Integer)}, que busca os detalhes de uma
+     * exceção na enumeração {@link ExceptionDetails} baseado no termo fornecido.
+     * <p>
+     * O minimalismo deste construtor facilita sua utilização ao longo das várias partes do código onde é necessário
+     * lançar esta exceção.
+     * <p>
+     * Caso o termo fornecido não corresponda a nenhum elemento na enumeração {@link ExceptionDetails}, uma exceção do
+     * tipo {@link DetailsFailureException} é lançada pelo método {@link #obtainExceptionDetails(Integer)}.
+     *
+     * @param term um número inteiro que representa a chave do erro na enumeração {@link ExceptionDetails}.
+     * @throws DetailsFailureException se nenhuma correspondência for encontrada na enumeração {@link ExceptionDetails}
+     *                                 para o termo fornecido.
+     */
     public ShelterEntityFailuresException(Integer term) {
         super(obtainExceptionDetails(term));
     }
 
     /**
-    * Uma exceção que será lançada quando ocorrer uma falha em uma operação relacionada ao {@link ShelterEntity}.
-    * A exceção contém uma mensagem de erro detalhada.
-    *
-    * @param message A mensagem específica da exceção.
-    */
+     * Uma exceção que será lançada quando ocorrer uma falha em uma operação relacionada ao {@link ShelterEntity}.
+     * A exceção contém uma mensagem de erro detalhada.
+     *
+     * @param message A mensagem específica da exceção.
+     */
     public ShelterEntityFailuresException(Integer term, String message) {
         super(message, obtainExceptionDetails(term));
     }
 
+    /**
+     * Construtor para a classe {@link ShelterEntityFailuresException}.
+     * Este construtor aceita dois parâmetros:
+     * <br>
+     * {@link Integer} - representa a chave para o erro na enumeração {@link ExceptionDetails}, e
+     * <br>
+     * {@link Throwable} - representa a causa do erro.
+     * <p>
+     * O termo é usado para obter os detalhes de uma exceção específica, como a mensagem de erro,
+     * o código de erro HTTP associado, etc., através do método {@link #obtainExceptionDetails(Integer)},
+     * que busca o detalhe da exceção na enumeração {@link ExceptionDetails}.
+     * Se nenhum erro correspondente for encontrado na enumeração {@link ExceptionDetails} para o termo fornecido,
+     * {@link DetailsFailureException} é lançada pelo método {@link #obtainExceptionDetails(Integer)}.
+     * <p>
+     * A simplicidade deste construtor facilita seu uso em várias partes do código
+     * onde é necessário lançar essa exceção.
+     *
+     * @param term  um inteiro que é usado como uma chave para o erro na enumeração {@link ExceptionDetails}.
+     * @param cause a causa original do erro.
+     * @throws DetailsFailureException se nenhum erro correspondente for encontrado no {@link ExceptionDetails}
+     *                                 enumeração para o termo fornecido.
+     */
     public ShelterEntityFailuresException(Integer term, Throwable cause) {
         super(cause, obtainExceptionDetails(term));
     }
 
     /**
-    * Uma exceção que será lançada quando ocorrer uma falha em uma operação relacionada ao {@link ShelterEntity}.
-    * A exceção contém uma mensagem de erro detalhada e a causa original do erro.
-    *
-    * @param message A mensagem específica da exceção.
-    * @param cause A causa original do erro.
-    */
+     * Uma exceção que será lançada quando ocorrer uma falha em uma operação relacionada ao {@link ShelterEntity}.
+     * A exceção contém uma mensagem de erro detalhada e a causa original do erro.
+     *
+     * @param message A mensagem específica da exceção.
+     * @param cause   A causa original do erro.
+     */
     public ShelterEntityFailuresException(Integer term, String message, Throwable cause) {
         super(message, cause, obtainExceptionDetails(term));
     }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/UserEntityFailuresException.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/UserEntityFailuresException.java
@@ -10,33 +10,73 @@ import diegosneves.github.conectardoacoes.core.domain.user.entity.User;
  * Herda de {@link RuntimeException} e adiciona mensagens de erro detalhadas para os erros que podem ocorrer
  * durante as operações de manipulação dos dados da entidade {@link User}.
  *
- *
  * @author diegoneves
  * @since 1.0.0
  */
-public class UserEntityFailuresException extends RuntimeException {
-
-    public static final ExceptionDetails ERROR = ExceptionDetails.USER_OPERATION_FAILURE;
+public class UserEntityFailuresException extends CustomException {
 
     /**
-    * Uma exceção que será lançada quando ocorrer uma falha em uma operação relacionada ao {@link UserEntity}.
-    * A exceção contém uma mensagem de erro detalhada.
-    *
-    * @param message A mensagem específica da exceção.
-    */
-    public UserEntityFailuresException(String message) {
-        super(ERROR.formatErrorMessage(message));
+     * Construtor da exceção {@link UserEntityFailuresException}. Este construtor recebe um código de termo
+     * que representa o erro ocorrido.
+     * <p>
+     * O código de termo é utilizado para obter os detalhes correspondentes à excecção através do método
+     * {@link #obtainExceptionDetails(Integer)}. Cada exceção possui uma mensagem de erro associada, um
+     * código de estado HTTP, entre outros detalhes, que são encapsulados na instância de {@link ExceptionDetails}
+     * retornada pelo método mencionado.
+     * <p>
+     * A mensagem detelhada da exceção é então passada para a classe parent {@link CustomException} através
+     * do método super().
+     *
+     * @param term um número inteiro representando a chave do erro na enumeração {@link ExceptionDetails}.
+     * @throws DetailsFailureException se nenhum elemento da enumeração corresponder ao termo fornecido. Esta
+     *                                 exceção seria lançada pelo método {@link #obtainExceptionDetails(Integer)}.
+     */
+    public UserEntityFailuresException(Integer term) {
+        super(obtainExceptionDetails(term));
     }
 
     /**
-    * Uma exceção que será lançada quando ocorrer uma falha em uma operação relacionada ao {@link UserEntity}.
-    * A exceção contém uma mensagem de erro detalhada e a causa original do erro.
-    *
-    * @param message A mensagem específica da exceção.
-    * @param cause A causa original do erro.
-    */
-    public UserEntityFailuresException(String message, Throwable cause) {
-        super(ERROR.formatErrorMessage(message), cause);
+     * Uma exceção que será lançada quando ocorrer uma falha em uma operação relacionada ao {@link UserEntity}.
+     * A exceção contém uma mensagem de erro detalhada.
+     *
+     * @param message A mensagem específica da exceção.
+     */
+    public UserEntityFailuresException(Integer term, String message) {
+        super(message, obtainExceptionDetails(term));
+    }
+
+    /**
+     * Constrói uma nova instância da classe de exceção {@link UserEntityFailuresException} com um {@code term}
+     * específico que representa o tipo de erro e uma causa original da exceção.
+     * <p>
+     * Este construtor é comumente utilizado quando se quer encapsular uma exceção de baixo nível dentro
+     * da exceção personalizada {@code UserEntityFailuresException}. O {@code cause} é usado para preservar
+     * o rastreamento de pilha da exceção original.
+     * <p>
+     * O {@code term} é um número inteiro utilizado para descobrir os detalhes da exceção na enumeração
+     * {@code ExceptionDetails}. Cada erro/exceção tem um correlato na enumeração que determina varias informações
+     * como o código de estado HTTP, mensagem de erro padrão, etc.
+     *
+     * @param term  um numero inteiro que representa a chave do erro na enumeração {@link ExceptionDetails}.
+     *              Este valor é utilizado para obter os detalhes da exceção corrente.
+     * @param cause a causa original (pode ser recuperada pelo método {@link Throwable#getCause()}),
+     *              (A causa é permitida ser null, indicando que a causa é inexistente ou desconhecida)
+     * @throws DetailsFailureException se nenhum elemento da enumeração corresponder ao {@code term} fornecido.
+     *                                 Esta exceção seria lançada pelo método {@link #obtainExceptionDetails(Integer)}.
+     */
+    public UserEntityFailuresException(Integer term, Throwable cause) {
+        super(cause, obtainExceptionDetails(term));
+    }
+
+    /**
+     * Uma exceção que será lançada quando ocorrer uma falha em uma operação relacionada ao {@link UserEntity}.
+     * A exceção contém uma mensagem de erro detalhada e a causa original do erro.
+     *
+     * @param message A mensagem específica da exceção.
+     * @param cause   A causa original do erro.
+     */
+    public UserEntityFailuresException(Integer term, String message, Throwable cause) {
+        super(message, cause, obtainExceptionDetails(term));
     }
 
 }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/AddressEntityMapper.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/AddressEntityMapper.java
@@ -2,7 +2,6 @@ package diegosneves.github.conectardoacoes.adapters.rest.mapper;
 
 
 import diegosneves.github.conectardoacoes.adapters.rest.exception.AddressEntityFailuresException;
-import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
 import diegosneves.github.conectardoacoes.adapters.rest.model.AddressEntity;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Address;
 import diegosneves.github.conectardoacoes.core.utils.ValidationUtils;
@@ -35,7 +34,7 @@ public class AddressEntityMapper implements MapperStrategy<AddressEntity, Addres
      */
     @Override
     public AddressEntity mapFrom(Address source) {
-        ValidationUtils.validateNotNullOrEmpty(source, MapperFailureException.ERROR.formatErrorMessage(ADDRESS_CLASS.getSimpleName()), AddressEntityFailuresException.class);
+        ValidationUtils.validateNotNullOrEmpty(source, CLASS_MAPPING_FAILURE, ADDRESS_CLASS.getSimpleName(), AddressEntityFailuresException.class);
         return BuilderMapper.mapTo(AddressEntity.class, source);
     }
 

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/AddressMapper.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/AddressMapper.java
@@ -1,7 +1,6 @@
 package diegosneves.github.conectardoacoes.adapters.rest.mapper;
 
 import diegosneves.github.conectardoacoes.adapters.rest.exception.AddressEntityFailuresException;
-import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
 import diegosneves.github.conectardoacoes.adapters.rest.model.AddressEntity;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Address;
 import diegosneves.github.conectardoacoes.core.exception.AddressCreationFailureException;
@@ -44,13 +43,13 @@ public class AddressMapper implements MapperStrategy<Address, AddressEntity> {
      */
     @Override
     public Address mapFrom(AddressEntity source) {
-        ValidationUtils.validateNotNullOrEmpty(source, MapperFailureException.ERROR.formatErrorMessage(ADDRESS_ENTITY_TYPE.getSimpleName()), AddressEntityFailuresException.class);
+        ValidationUtils.validateNotNullOrEmpty(source, CLASS_MAPPING_FAILURE, ADDRESS_ENTITY_TYPE.getSimpleName(), AddressEntityFailuresException.class);
         Address address;
         try {
             address = new Address(source.getId(), source.getStreet(), source.getNumber(), source.getNeighborhood(), source.getCity(), source.getState(), source.getZip());
         } catch (AddressCreationFailureException e) {
             log.error(MAPPING_ERROR_LOG, e.getMessage(), e);
-            throw new AddressEntityFailuresException(MapperFailureException.ERROR.formatErrorMessage(ADDRESS_ENTITY_TYPE.getSimpleName()), e);
+            throw new AddressEntityFailuresException(CLASS_MAPPING_FAILURE, ADDRESS_ENTITY_TYPE.getSimpleName(), e);
         }
         return address;
     }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/BuilderMapper.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/BuilderMapper.java
@@ -1,5 +1,6 @@
 package diegosneves.github.conectardoacoes.adapters.rest.mapper;
 
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.ConstructorDefaultUndefinedException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
 import diegosneves.github.conectardoacoes.core.utils.ValidationUtils;
@@ -20,6 +21,7 @@ public class BuilderMapper {
 
     public static final String SOURCE_OBJECT_NULL_ERROR_MESSAGE = "O objeto que está sendo mapeado não deve ser nulo. Verifique se o objeto foi corretamente inicializado.";
     public static final String STRATEGY_CANNOT_BE_NULL = "O objeto MapperStrategy não pode ser nulo";
+    public static final Integer CLASS_MAPPING_FAILURE = 4;
 
     private BuilderMapper() {
     }
@@ -68,13 +70,13 @@ public class BuilderMapper {
                 mappedInstance = (T) nextConstructor.newInstance(paramValues);
 
             } else {
-                log.error(ConstructorDefaultUndefinedException.ERROR.formatErrorMessage(destinationClass.getName()));
-                throw new ConstructorDefaultUndefinedException(destinationClass.getName());
+                log.error(ExceptionDetails.getExceptionDetails(CLASS_MAPPING_FAILURE).formatErrorMessage(destinationClass.getName()));
+                throw new ConstructorDefaultUndefinedException(CLASS_MAPPING_FAILURE, destinationClass.getName());
             }
 
         } catch (Exception e) {
-            log.error(MapperFailureException.ERROR.formatErrorMessage(destinationClass.getName()), e);
-            throw new MapperFailureException(destinationClass.getName(), e);
+            log.error(ExceptionDetails.getExceptionDetails(CLASS_MAPPING_FAILURE).formatErrorMessage(destinationClass.getName()), e);
+            throw new MapperFailureException(CLASS_MAPPING_FAILURE, destinationClass.getName(), e);
         }
 
         for (Field field : destinationFields) {

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/DonationEntityMapper.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/DonationEntityMapper.java
@@ -34,7 +34,8 @@ public class DonationEntityMapper implements MapperStrategy<DonationEntity, Dona
     public DonationEntity mapFrom(Donation source) {
         ValidationUtils.validateNotNullOrEmpty(
                 source,
-                MapperFailureException.ERROR.formatErrorMessage(DONATION_CLASS.getSimpleName()),
+                CLASS_MAPPING_FAILURE,
+                DONATION_CLASS.getSimpleName(),
                 ShelterEntityFailuresException.class);
         return BuilderMapper.mapTo(DonationEntity.class, source);
     }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/DonationMapper.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/DonationMapper.java
@@ -1,6 +1,5 @@
 package diegosneves.github.conectardoacoes.adapters.rest.mapper;
 
-import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.ShelterEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.model.DonationEntity;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Donation;
@@ -52,7 +51,8 @@ public class DonationMapper implements MapperStrategy<Donation, DonationEntity> 
     public Donation mapFrom(DonationEntity source) {
         ValidationUtils.validateNotNullOrEmpty(
                 source,
-                MapperFailureException.ERROR.formatErrorMessage(DonationEntity.class.getSimpleName()),
+                CLASS_MAPPING_FAILURE,
+                DonationEntity.class.getSimpleName(),
                 ShelterEntityFailuresException.class);
 
         Donation donation;
@@ -60,7 +60,7 @@ public class DonationMapper implements MapperStrategy<Donation, DonationEntity> 
             donation = new Donation(source.getId(), source.getDescription(), source.getAmount());
         } catch (DonationRegisterFailureException e) {
             log.error(MAPPING_ERROR_LOG, e.getMessage(), e);
-            throw new ShelterEntityFailuresException(MapperFailureException.ERROR.formatErrorMessage(DonationEntity.class.getSimpleName()), e);
+            throw new ShelterEntityFailuresException(CLASS_MAPPING_FAILURE, DonationEntity.class.getSimpleName(), e);
         }
         return donation;
     }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/MapperStrategy.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/MapperStrategy.java
@@ -11,6 +11,8 @@ package diegosneves.github.conectardoacoes.adapters.rest.mapper;
  */
 public interface MapperStrategy<T, E> {
 
+    Integer CLASS_MAPPING_FAILURE = 4;
+
     /**
      * Executa a estratégia para realizar uma operação de mapeamento entre objetos.
      *

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/ShelterEntityMapper.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/ShelterEntityMapper.java
@@ -1,7 +1,6 @@
 package diegosneves.github.conectardoacoes.adapters.rest.mapper;
 
 
-import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.ShelterEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.model.AddressEntity;
 import diegosneves.github.conectardoacoes.adapters.rest.model.DonationEntity;
@@ -50,7 +49,7 @@ public class ShelterEntityMapper implements MapperStrategy<ShelterEntity, Shelte
      */
     @Override
     public ShelterEntity mapFrom(ShelterContract source) {
-        ValidationUtils.validateNotNullOrEmpty(source, MapperFailureException.ERROR.formatErrorMessage(SHELTER_CLASS.getSimpleName()), ShelterEntityFailuresException.class);
+        ValidationUtils.validateNotNullOrEmpty(source, CLASS_MAPPING_FAILURE, SHELTER_CLASS.getSimpleName(), ShelterEntityFailuresException.class);
         ShelterEntity shelterEntity;
 
         try {
@@ -63,7 +62,7 @@ public class ShelterEntityMapper implements MapperStrategy<ShelterEntity, Shelte
                     .build();
         } catch (RuntimeException e) {
             log.error(MAPPING_ERROR_LOG, e.getMessage(), e);
-            throw new ShelterEntityFailuresException(MapperFailureException.ERROR.formatErrorMessage(SHELTER_CLASS.getSimpleName()), e);
+            throw new ShelterEntityFailuresException(CLASS_MAPPING_FAILURE, SHELTER_CLASS.getSimpleName(), e);
         }
         return shelterEntity;
     }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/ShelterMapper.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/ShelterMapper.java
@@ -1,6 +1,5 @@
 package diegosneves.github.conectardoacoes.adapters.rest.mapper;
 
-import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.ShelterEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.model.DonationEntity;
 import diegosneves.github.conectardoacoes.adapters.rest.model.ShelterEntity;
@@ -57,7 +56,7 @@ public class ShelterMapper implements MapperStrategy<ShelterContract, ShelterEnt
      */
     @Override
     public ShelterContract mapFrom(ShelterEntity source) {
-        ValidationUtils.validateNotNullOrEmpty(source, MapperFailureException.ERROR.formatErrorMessage(SHELTER_ENTITY_CLASS.getSimpleName()), ShelterEntityFailuresException.class);
+        ValidationUtils.validateNotNullOrEmpty(source, CLASS_MAPPING_FAILURE, SHELTER_ENTITY_CLASS.getSimpleName(), ShelterEntityFailuresException.class);
 
         Shelter constructedShelter;
         try {
@@ -68,7 +67,7 @@ public class ShelterMapper implements MapperStrategy<ShelterContract, ShelterEnt
                     new UserMapper().mapFrom(source.getResponsibleUser()));
         } catch (RuntimeException e) {
             log.error(MAPPING_ERROR_LOG, e.getMessage(), e);
-            throw new ShelterEntityFailuresException(MapperFailureException.ERROR.formatErrorMessage(SHELTER_ENTITY_CLASS.getSimpleName()), e);
+            throw new ShelterEntityFailuresException(CLASS_MAPPING_FAILURE, SHELTER_ENTITY_CLASS.getSimpleName(), e);
         }
         this.mappedDonationsToShelter(source, constructedShelter);
         return constructedShelter;
@@ -101,7 +100,7 @@ public class ShelterMapper implements MapperStrategy<ShelterContract, ShelterEnt
                 constructedShelter.addDonation(new Donation(donationEntity.getId(), donationEntity.getDescription(), donationEntity.getAmount()));
             } catch (DonationRegisterFailureException e) {
                 log.error(MAPPING_ERROR_LOG, e.getMessage(), e);
-                throw new ShelterEntityFailuresException(MapperFailureException.ERROR.formatErrorMessage(Donation.class.getSimpleName()), e);
+                throw new ShelterEntityFailuresException(CLASS_MAPPING_FAILURE, Donation.class.getSimpleName(), e);
             }
         }
     }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/UserEntityMapper.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/UserEntityMapper.java
@@ -1,7 +1,7 @@
 package diegosneves.github.conectardoacoes.adapters.rest.mapper;
 
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.enums.UserProfileType;
-import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.UserEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.model.UserEntity;
 import diegosneves.github.conectardoacoes.core.domain.user.entity.User;
@@ -28,14 +28,14 @@ public class UserEntityMapper implements MapperStrategy<UserEntity, UserContract
      * Este método é usado para mapear um objeto de origem do tipo {@link User} para um objeto de entidade {@link UserEntity}.
      * <p>
      * Primeiro, realiza uma verificação de not-null-or-empty do objeto de origem utilizando a utilidade {@link ValidationUtils}.
-     * Se o objeto de origem for nulo ou vazio, um {@link UserEntityFailuresException} será lançado com a mensagem de erro gerada por {@link MapperFailureException#ERROR}.
+     * Se o objeto de origem for nulo ou vazio, um {@link UserEntityFailuresException} será lançado com a mensagem de erro gerada por {@link ExceptionDetails}.
      * </p>
      * <p>
      * Em seguida, tenta mapear o objeto de origem para a classe {@link UserEntity} usando a utilidade {@link BuilderMapper}.
      * Após o mapeamento bem-sucedido, ele então tenta configurar o perfil do usuário no objeto de entidade mapeado. O perfil do usuário é obtido a partir do perfil do usuário do objeto de origem e convertido para uma enumeração de {@link UserProfileType}.
      * </p>
      * <p>
-     * Se um {@link RuntimeException} é lançado durante o mapeamento ou a configuração do perfil do usuário, um novo {@link UserEntityFailuresException} é lançado com a mensagem de erro gerada por {@link MapperFailureException#ERROR} e a exceção original anexada para fins de rastreamento.
+     * Se um {@link RuntimeException} é lançado durante o mapeamento ou a configuração do perfil do usuário, um novo {@link UserEntityFailuresException} é lançado com a mensagem de erro gerada por {@link ExceptionDetails} e a exceção original anexada para fins de rastreamento.
      * </p>
      * O objeto {@link UserEntity} mapeado, ou nulo se não foi possível realizar o mapeamento, é retornado ao chamador.
      *
@@ -46,14 +46,14 @@ public class UserEntityMapper implements MapperStrategy<UserEntity, UserContract
      */
     @Override
     public UserEntity mapFrom(UserContract source) {
-        ValidationUtils.validateNotNullOrEmpty(source, MapperFailureException.ERROR.formatErrorMessage(USER_CLASS.getSimpleName()), UserEntityFailuresException.class);
+        ValidationUtils.validateNotNullOrEmpty(source, CLASS_MAPPING_FAILURE, USER_CLASS.getSimpleName(), UserEntityFailuresException.class);
         UserEntity userEntity;
         try {
             userEntity = BuilderMapper.mapTo(UserEntity.class, source);
             userEntity.setUserProfile(Enum.valueOf(UserProfileType.class, source.getUserProfile().name()));
         } catch (RuntimeException e) {
             log.error(MAPPING_ERROR_LOG, e.getMessage(), e);
-            throw new UserEntityFailuresException(MapperFailureException.ERROR.formatErrorMessage(USER_CLASS.getSimpleName()), e);
+            throw new UserEntityFailuresException(CLASS_MAPPING_FAILURE, USER_CLASS.getSimpleName(), e);
         }
         return userEntity;
     }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/UserMapper.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/UserMapper.java
@@ -1,5 +1,6 @@
 package diegosneves.github.conectardoacoes.adapters.rest.mapper;
 
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.UserEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.model.UserEntity;
@@ -54,7 +55,7 @@ public class UserMapper implements MapperStrategy<UserContract, UserEntity> {
                     source.getUserPassword());
         } catch (UserCreationFailureException e) {
             log.error(MAPPING_ERROR_LOG, e.getMessage(), e);
-            throw new UserEntityFailuresException(MapperFailureException.ERROR.formatErrorMessage(USER_ENTITY_CLASS.getSimpleName()), e);
+            throw new UserEntityFailuresException(CLASS_MAPPING_FAILURE, USER_ENTITY_CLASS.getSimpleName(), e);
         }
         return mappedUser;
     }
@@ -67,13 +68,13 @@ public class UserMapper implements MapperStrategy<UserContract, UserEntity> {
      * @param <T>  o tipo de dado a ser validado. Como este é um método genérico, ele pode aceitar qualquer tipo de objeto.
      * @param data o dado a ser validado.
      * @throws UserEntityFailuresException se o dado fornecido for nulo ou, no caso de Strings, estiver vazio.
-     *                                     A mensagem da exceção será uma mensagem de erro formatada a partir do {@link MapperFailureException#ERROR} anexada com a
+     *                                     A mensagem da exceção será uma mensagem de erro formatada a partir do {@link ExceptionDetails} anexada com a
      *                                     simplificação do nome da classe {@link UserEntity}.
      * @see ValidationUtils
      * @see MapperFailureException
      */
     private <T> void validateData(T data) throws UserEntityFailuresException {
-        ValidationUtils.validateNotNullOrEmpty(data, MapperFailureException.ERROR.formatErrorMessage(USER_ENTITY_CLASS.getSimpleName()), UserEntityFailuresException.class);
+        ValidationUtils.validateNotNullOrEmpty(data, CLASS_MAPPING_FAILURE, USER_ENTITY_CLASS.getSimpleName(), UserEntityFailuresException.class);
     }
 
 }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/repository/ShelterRepository.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/repository/ShelterRepository.java
@@ -38,8 +38,9 @@ import java.util.Optional;
 public interface ShelterRepository extends ShelterContractRepository, CrudRepository<ShelterEntity, String> {
 
 
-    String INVALID_ID_MESSAGE = "Deve ser fornecido um ID válido!";
-    String SHELTER_ERROR_MESSAGE = "Um objeto Abrigo válido deve ser fornecido para persistência!";
+    Integer INVALID_ID_MESSAGE = 19;
+    Integer SHELTER_ERROR_MESSAGE = 21;
+    Integer INVALID_UUID_FORMAT_MESSAGE = 6;
 
     /**
      * Retorna uma nova instância do {@link MapperStrategy} para mapear uma entidade {@link ShelterEntity} para a classe de domínio {@link Shelter}.
@@ -69,7 +70,7 @@ public interface ShelterRepository extends ShelterContractRepository, CrudReposi
         try {
             UuidUtils.isValidUUID(id);
         } catch (UuidUtilsException e) {
-            throw new ShelterEntityFailuresException(INVALID_ID_MESSAGE, e);
+            throw new ShelterEntityFailuresException(INVALID_UUID_FORMAT_MESSAGE, id, e);
         }
     }
 

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/repository/UserRepository.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/repository/UserRepository.java
@@ -31,8 +31,9 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends UserContractRepository, CrudRepository<UserEntity, String> {
 
-    String USER_ID_ERROR_MESSAGE = "Operação não realizada. Um ID de usuário válido deve ser fornecido.";
-    String REQUIRED_USER_ERROR_MESSAGE = "Um usuário válido é requerido para efetuar a persistência.";
+    Integer INVALID_ID_MESSAGE = 19;
+    Integer REQUIRED_USER_ERROR_MESSAGE = 35;
+    Integer INVALID_UUID_FORMAT_MESSAGE = 6;
 
     /**
      * Este método busca um usuário pelo email fornecido e retorna um {@link Optional} de {@link UserEntity}.
@@ -99,11 +100,11 @@ public interface UserRepository extends UserContractRepository, CrudRepository<U
      * @throws UserEntityFailuresException Se o ID do usuário for nulo, vazio ou não for um UUID válido.
      */
     private void validateUserId(String id) throws UserEntityFailuresException {
-        ValidationUtils.validateNotNullOrEmpty(id, USER_ID_ERROR_MESSAGE, UserEntityFailuresException.class);
+        ValidationUtils.validateNotNullOrEmpty(id, INVALID_ID_MESSAGE, UserEntityFailuresException.class);
         try {
             UuidUtils.isValidUUID(id);
         } catch (UuidUtilsException e) {
-            throw new UserEntityFailuresException(USER_ID_ERROR_MESSAGE, e);
+            throw new UserEntityFailuresException(INVALID_UUID_FORMAT_MESSAGE, id, e);
         }
     }
 

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/AddressEntityServiceImpl.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/AddressEntityServiceImpl.java
@@ -43,8 +43,8 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class AddressEntityServiceImpl implements AddressEntityService {
 
-    public static final String ADDRESS_CREATION_ERROR = "Erro na criação do endereço. Confirme se todos os campos do endereço estão corretos e tente novamente.";
-    public static final String ERROR_MAPPING_ADDRESS = "Erro durante o mapeamento do endereço para persistência";
+    public static final Integer ADDRESS_CREATION_ERROR = 23;
+    public static final Integer ERROR_MAPPING_ADDRESS = 25;
 
     public static final String CREATION_FAILURE_LOG = "Falha na tentativa de criação de um novo Endereço. Causa do erro: {}";
     public static final String ADDRESS_MAPPING_ERROR_LOG = "Ocorreu uma falha ao tentar mapear o Endereço. Causa do erro: {}";

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/DonationEntityServiceImpl.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/DonationEntityServiceImpl.java
@@ -47,7 +47,7 @@ public class DonationEntityServiceImpl implements DonationEntityService {
 
     @Override
     public DonationEntity convertAndSaveDonationDTO(DonationDTO donationDTO) {
-        ValidationUtils.validateNotNullOrEmpty(donationDTO, INVALID_DONATION_INFO_ERROR, DonationEntityFailuresException.class);
+        ValidationUtils.validateNotNullOrEmpty(donationDTO, 5, INVALID_DONATION_INFO_ERROR, DonationEntityFailuresException.class);
         return this.convertDonationDTOToDonationEntity(donationDTO);
     }
 
@@ -86,7 +86,7 @@ public class DonationEntityServiceImpl implements DonationEntityService {
             created = DonationFactory.created(donationDTO.getDescription(), donationDTO.getAmount());
         } catch (RuntimeException e) {
             log.error(DONATION_CREATION_ERROR_LOG, e.getMessage(), e);
-            throw new DonationEntityFailuresException(DONATION_CREATION_FAILURE, e);
+            throw new DonationEntityFailuresException(5, DONATION_CREATION_FAILURE, e);
         }
         return created;
     }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/ShelterEntityServiceImpl.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/ShelterEntityServiceImpl.java
@@ -3,6 +3,7 @@ package diegosneves.github.conectardoacoes.adapters.rest.service.impl;
 import diegosneves.github.conectardoacoes.adapters.rest.dto.AddressDTO;
 import diegosneves.github.conectardoacoes.adapters.rest.dto.DonationDTO;
 import diegosneves.github.conectardoacoes.adapters.rest.dto.UserEntityDTO;
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.ShelterEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.UserEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.mapper.BuilderMapper;
@@ -47,14 +48,14 @@ import java.util.Optional;
 @Slf4j
 public class ShelterEntityServiceImpl implements ShelterEntityService {
 
-    public static final String SHELTER_CREATION_ERROR_MESSAGE = "Erro na criação do Abrigo. Confirme se todos os campos do Abrigo estão corretos e tente novamente.";
-    public static final String USER_RESPONSIBLE_EMAIL_NOT_FOUND_ERROR = "Ops! Não conseguimos encontrar o e-mail do usuário responsável. Por gentileza, tente novamente.";
-    public static final String REQUEST_VALIDATION_ERROR_MESSAGE = "Por favor, forneça uma requisição de criação de Abrigo preenchida corretamente.";
-    public static final String RESPONSIBLE_USER_PROFILE_INVALID = "O usuário deve possuir o perfil de responsável.";
-    public static final String RESPONSIBLE_USER_ALREADY_IN_USE = "Este usuário já possui responsabilidade sobre outro abrigo.";
-    public static final String DONATION_VALIDATION_ERROR = "Para o cadastro de doações, é indispensável fornecer informações válidas e completas.";
-    public static final String EMPTY_DONATION_LIST = "Até o momento, não há doações listadas.";
-    public static final String RESPONSIBLE_EMAIL_NOT_ASSOCIATED_WITH_SHELTER = "Por favor, verifique se o e-mail do usuário responsável está correto e associado a um abrigo. Caso contrário, certifique-se de que o usuário responsável tenha um e-mail válido em nosso sistema.";
+    public static final Integer SHELTER_CREATION_ERROR_MESSAGE = 5;
+    public static final Integer USER_RESPONSIBLE_EMAIL_NOT_FOUND_ERROR = 11;
+    public static final Integer REQUEST_VALIDATION_ERROR_MESSAGE = 3;
+    public static final Integer RESPONSIBLE_USER_PROFILE_INVALID = 7;
+    public static final Integer RESPONSIBLE_USER_ALREADY_IN_USE = 9;
+    public static final Integer DONATION_VALIDATION_ERROR = 13;
+    public static final Integer EMPTY_DONATION_LIST = 15;
+    public static final Integer RESPONSIBLE_EMAIL_NOT_ASSOCIATED_WITH_SHELTER = 17;
 
     public static final String SHELTER_CREATION_SUCCESS_LOG = "Novo abrigo criado com sucesso. Detalhes: ID do Abrigo: {} - Email do Usuário Responsável: {}";
     public static final String SHELTER_CREATION_FAILURE_LOG = "Falha ao instanciar e retornar um Abrigo. Causa: {}";
@@ -206,14 +207,14 @@ public class ShelterEntityServiceImpl implements ShelterEntityService {
      *
      * @param needToThrowAnException a condição Booleana segundo a qual a exceção deve ser lançada.
      *                               Se for verdadeiro, a {@link ShelterEntityFailuresException} será lançada.
-     * @param errorMessage           a String que representa a mensagem detalhada da exceção. Esta mensagem é utilizada
+     * @param errorCode           o Integer que representa a mensagem detalhada da exceção. Esta mensagem é utilizada
      *                               quando a exceção é lançada.
      * @throws ShelterEntityFailuresException a exceção customizada que será lançada quando {@code needToThrowAnException} for verdadeiro.
      */
-    private static void throwShelterEntityFailuresExceptionIfNecessary(Boolean needToThrowAnException, String errorMessage) throws ShelterEntityFailuresException {
+    private static void throwShelterEntityFailuresExceptionIfNecessary(Boolean needToThrowAnException, Integer errorCode) throws ShelterEntityFailuresException {
         if (Boolean.TRUE.equals(needToThrowAnException)) {
-            log.error(RESPONSIBLE_USER_VERIFICATION_ERROR_LOG, errorMessage);
-            throw new ShelterEntityFailuresException(errorMessage);
+            log.error(RESPONSIBLE_USER_VERIFICATION_ERROR_LOG, ExceptionDetails.getExceptionDetails(errorCode).formatErrorMessage());
+            throw new ShelterEntityFailuresException(errorCode);
         }
     }
 

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/UserEntityServiceImpl.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/UserEntityServiceImpl.java
@@ -39,12 +39,12 @@ import java.util.Optional;
 @Slf4j
 public class UserEntityServiceImpl implements UserEntityService {
 
-    public static final String INVALID_EMAIL_ERROR_MESSAGE = "Não foi informado nenhum email. Por favor, forneça um email válido.";
-    public static final String EMAIL_NOT_FOUND_ERROR_MESSAGE = "Não foi possivel encontrar um usuário com o email [ %s ].";
-    public static final String EMAIL_ALREADY_IN_USE = "Desculpe, o endereço de email fornecido já está associado a uma conta existente. Por favor, tente com um email diferente.";
-    public static final String USER_CREATION_FAILURE_MESSAGE = "Ops! A criação do novo usuário não foi bem-sucedida. Por favor, certifique-se de que seus dados estão corretos e tente novamente.";
-    public static final String USER_PROFILE_VALIDATION_FAILURE = "A validação do Perfil do usuário fornecido falhou.";
-    public static final String MISSING_USER_ENTITY_REQUEST_ERROR_MESSAGE = "Por favor, forneça uma requisição de criação de usuário preenchida corretamente.";
+    public static final Integer INVALID_EMAIL_ERROR_MESSAGE = 29;
+    public static final Integer EMAIL_NOT_FOUND_ERROR_MESSAGE = 8;
+    public static final Integer EMAIL_ALREADY_IN_USE = 10;
+    public static final Integer USER_CREATION_FAILURE_MESSAGE = 31;
+    public static final Integer USER_PROFILE_VALIDATION_FAILURE = 33;
+    public static final Integer MISSING_USER_ENTITY_REQUEST_ERROR_MESSAGE = 27;
 
     public static final String USER_CREATION_ERROR_LOG = "Ocorreu um erro ao tentar criar um usuário a partir da solicitação de criação UserEntityCreationRequest: {}";
     public static final String EMAIL_DUPLICATE_LOG = "O endereço de email {} já está associado a uma conta existente";
@@ -61,7 +61,7 @@ public class UserEntityServiceImpl implements UserEntityService {
     @Override
     public UserContract searchUserByEmail(String email) throws UserEntityFailuresException {
         ValidationUtils.validateNotNullOrEmpty(email, INVALID_EMAIL_ERROR_MESSAGE, UserEntityFailuresException.class);
-        UserEntity foundUser = this.userRepository.findByEmail(email).orElseThrow(() -> new UserEntityFailuresException(String.format(EMAIL_NOT_FOUND_ERROR_MESSAGE, email)));
+        UserEntity foundUser = this.userRepository.findByEmail(email).orElseThrow(() -> new UserEntityFailuresException(EMAIL_NOT_FOUND_ERROR_MESSAGE, email));
         return BuilderMapper.mapTo(new UserMapper(), foundUser);
     }
 
@@ -155,7 +155,7 @@ public class UserEntityServiceImpl implements UserEntityService {
         Optional<UserEntity> existingUser = this.userRepository.findByEmail(email);
         if (existingUser.isPresent()) {
             log.error(EMAIL_DUPLICATE_LOG, email);
-            throw new UserEntityFailuresException(EMAIL_ALREADY_IN_USE);
+            throw new UserEntityFailuresException(EMAIL_ALREADY_IN_USE, email);
         }
     }
 }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/UserEntityServiceImpl.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/UserEntityServiceImpl.java
@@ -14,7 +14,6 @@ import diegosneves.github.conectardoacoes.core.domain.user.entity.UserContract;
 import diegosneves.github.conectardoacoes.core.domain.user.entity.value.UserProfile;
 import diegosneves.github.conectardoacoes.core.domain.user.factory.UserFactory;
 import diegosneves.github.conectardoacoes.core.utils.ValidationUtils;
-import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -76,11 +75,25 @@ public class UserEntityServiceImpl implements UserEntityService {
 
     @Override
     public UserEntityCreatedResponse findUserByEmail(String email) {
+        UserEntity entity = BuilderMapper.mapTo(getUserEntityMapper(), this.searchUserByEmail(email));
+        return BuilderMapper.mapTo(UserEntityCreatedResponse.class, entity);
+    }
 
-        UserEntity foundedUserByEmail = userRepository.findByEmail(email).orElseThrow(
-                () -> new UserEntityFailuresException(String.format(EMAIL_NOT_FOUND_ERROR_MESSAGE, email)));
-
-        return BuilderMapper.mapTo(UserEntityCreatedResponse.class, foundedUserByEmail);
+    /**
+     * Retorna uma nova instância de {@link UserEntityMapper}.
+     *
+     * <p>
+     * Este método cria e retorna uma nova instância de {@link UserEntityMapper}.
+     * É usado para transformar {@link User} em {@link UserEntity} e vice-versa.
+     * A classe {@code UserEntityMapper} é um mapper (conversor) usado no contexto
+     * de persistência de dados da aplicação, convertendo objetos de domínio em entidades
+     * de banco de dados e vice versa em operações de CRUD.
+     *
+     * @return uma nova instância de {@link UserEntityMapper}
+     * @see UserEntityMapper
+     */
+    private static UserEntityMapper getUserEntityMapper() {
+        return new UserEntityMapper();
     }
 
 
@@ -101,7 +114,7 @@ public class UserEntityServiceImpl implements UserEntityService {
      */
     private static UserEntity createUserEntityFromCreationRequest(UserEntityCreationRequest request) {
         UserContract userContract = createUserFromRequest(request);
-        return BuilderMapper.mapTo(new UserEntityMapper(), userContract);
+        return BuilderMapper.mapTo(getUserEntityMapper(), userContract);
     }
 
     /**

--- a/src/main/java/diegosneves/github/conectardoacoes/core/exception/ValidationUtilsException.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/core/exception/ValidationUtilsException.java
@@ -14,7 +14,7 @@ import diegosneves.github.conectardoacoes.core.enums.ExceptionDetails;
  * </p>
  *
  * @author diegoneves
- * @see      RuntimeException
+ * @see RuntimeException
  * @since 1.0.0
  */
 public class ValidationUtilsException extends RuntimeException {
@@ -22,12 +22,26 @@ public class ValidationUtilsException extends RuntimeException {
     public static final ExceptionDetails ERROR = ExceptionDetails.EXCEPTION_TYPE_NOT_THROWN;
 
     /**
+     * Construtor para a classe {@link ValidationUtilsException}.
+     * Este construtor aceita uma string representando a mensagem de erro detalhada a ser usada ao construir a exceção.
+     * A mensagem é então passada para o método {@code buildMessage} do objeto {@code ERROR} (um instance de {@link ExceptionDetails}) para criar uma mensagem de erro formatada de maneira mais específica.
+     * O resultado final é passado para o construtor da superclasse {@link RuntimeException} para a construção da instancia da exceção.
+     *
+     * @param message A string que representa a mensagem detalhada da exceção. Esta string será usada para criar uma mensagem de erro mais detalhada através do método {@code buildMessage} do objeto {@code ERROR}.
+     * @throws RuntimeException Representa a exceção lançada quando ocorre um erro na validação de uma operação específica no contexto do seu uso.
+     * @see ExceptionDetails#buildMessage(String)
+     */
+    public ValidationUtilsException(String message) {
+        super(ERROR.buildMessage(message));
+    }
+
+    /**
      * Construtor que cria uma instância da exceção {@link ValidationUtilsException} com a mensagem e causa fornecidas.
      * A mensagem é usada para criar uma mensagem de erro mais detalhada, passada para a superclasse, {@link RuntimeException}.
      *
      * @param message A string que representa a mensagem detalhada da exceção, usada para criar uma mensagem de erro mais detalhada.
-     * @param cause A causa raiz da exceção, tipicamente uma instância de {@link Throwable} que levou à ocorrência desta exceção.
-     * Esta informação é usada para depuração e rastreamento do erro.
+     * @param cause   A causa raiz da exceção, tipicamente uma instância de {@link Throwable} que levou à ocorrência desta exceção.
+     *                Esta informação é usada para depuração e rastreamento do erro.
      */
     public ValidationUtilsException(String message, Throwable cause) {
         super(ERROR.buildMessage(message), cause);

--- a/src/main/java/diegosneves/github/conectardoacoes/core/utils/ValidationUtils.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/core/utils/ValidationUtils.java
@@ -1,5 +1,6 @@
 package diegosneves.github.conectardoacoes.core.utils;
 
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.core.exception.ValidationUtilsException;
 import lombok.extern.slf4j.Slf4j;
 
@@ -17,7 +18,15 @@ import java.util.List;
 @Slf4j
 public class ValidationUtils {
 
+    public static final String CUSTOM_EXCEPTION_ERROR = "CustomException. Uma exceção personalizada é necessária.";
+
     private ValidationUtils() {
+    }
+
+    public static <T> void validateNotNullOrEmpty(T input, Integer term, Class<? extends RuntimeException> customException) {
+        if (input == null || (input instanceof String string && string.trim().isEmpty())) {
+            throwException(term, customException);
+        }
     }
 
     /**
@@ -38,6 +47,44 @@ public class ValidationUtils {
     }
 
     /**
+     * Este método genérico garante que o objeto de entrada (um parâmetro genérico) não seja nulo ou vazio.
+     * Se o objeto for uma instância de String, ele verifica se a string, depois de ser aparada, ainda é vazia.
+     * Se o objeto for nulo ou uma instância de String que é vazia após o trim, ele lança uma exceção.
+     *
+     * @param input           - O objeto genérico que será verificado quanto à nulidade ou vazio. Isso pode ser qualquer tipo de objeto.
+     * @param term            - É um termo numérico que será usado na função de manipulação de exceção. Sua aplicação específica será determinada pela função que vai lidar com a exceção.
+     * @param errorMessage    - Esta é uma mensagem de erro personalizada que será passada para a função de manipulação de exceção. Isso permite que os usuários determinem a mensagem específica que será exibida quando a exceção for acionada.
+     * @param customException - A classe da exceção personalizada que será lançada se o objeto de entrada (input) for nulo ou se for uma instância da String que é vazia após ser cortada. Isso permite que o tipo exato de exceção que será lançada possa ser determinado em tempo de execução.
+     * @throws RuntimeException     - Se o objeto 'input' verificado é nulo ou uma instância de uma String que é vazia quando cortada, este método irá lançar uma instância da subclasse de RuntimeException especificada pelo parâmetro 'customException'.
+     * @throws NullPointerException - Se o parâmetro 'customException' for nulo, a implementação desta função provavelmente lançará um NullPointerException.
+     */
+    public static <T> void validateNotNullOrEmpty(T input, Integer term, String errorMessage, Class<? extends RuntimeException> customException) {
+        if (input == null || (input instanceof String string && string.trim().isEmpty())) {
+            throwException(term, errorMessage, customException);
+        }
+    }
+
+    /**
+     * Garante que a lista fornecida como parâmetro não seja nula nem vazia.
+     * <p>
+     * Este método verifica se a lista inputList fornecida é nula ou vazia. Se a lista for nula ou vazia,
+     * ele lança uma exceção personalizada do tipo fornecido. Além disso, valida se a exceção personalizada
+     * fornecida é instanciável e lança uma IllegalArgumentException se não for.
+     * </p>
+     *
+     * @param inputList       A lista que deve ser verificada para nulidade e vazio.
+     * @param term            Um termo ou parâmetro arbitrário que será usado durante a criação e lançamento de exceções.
+     * @param customException A classe da exceção personalizada a ser lançada se a lista estiver nula ou vazia.
+     * @throws IllegalArgumentException Se a classe customException não for uma RuntimeException instanciável.
+     */
+    public static <T> void ensureListIsNotNullOrEmpty(List<T> inputList, Integer term, Class<? extends RuntimeException> customException) {
+        validateCustomException(customException);
+        if (inputList == null || inputList.isEmpty()) {
+            throwException(term, customException);
+        }
+    }
+
+    /**
      * Garante que a lista de entrada não é nula e não está vazia.
      * Se a lista de entrada é nula ou vazia, uma exceção {@link RuntimeException} customizada é lançada com a mensagem de erro fornecida.
      * <p>
@@ -49,8 +96,46 @@ public class ValidationUtils {
      * @throws RuntimeException se a lista de entrada for nula ou vazia.
      */
     public static <T> void ensureListIsNotNullOrEmpty(List<T> inputList, String errorMessage, Class<? extends RuntimeException> customException) {
+        validateCustomException(customException);
         if (inputList == null || inputList.isEmpty()) {
             throwException(errorMessage, customException);
+        }
+    }
+
+    /**
+     * Valida se a lista fornecida está vazia ou é {@code null}.
+     * Se a lista é nula ou vazia, lança uma exceção definida pelo usuário com uma mensagem de erro e termo especificado.
+     *
+     * @param <T>             O tipo genérico da lista.
+     * @param inputList       A lista a ser verificada. Pode ser de qualquer tipo {@code <T>}.
+     * @param term            Um número inteiro que pode ser usado para representar um termo de erro ou código de erro específico.
+     * @param errorMessage    A mensagem de erro que deve ser incluída na exceção lançada caso a lista seja nula ou vazia.
+     * @param customException A classe de exceção definida pelo usuário a ser lançada caso a lista seja nula ou vazia.
+     *                        Deve estender {@code RuntimeException}.
+     * @throws ValidationUtilsException O método primeiro valida a instância {@code customException} para garantir que seja válida e instanciável.
+     *                                  Em seguida, verifica se a {@code inputList} é nula ou vazia. Se for uma dessas, a exceção {@code customException} é lançada
+     *                                  com o {@code term} e a {@code errorMessage} fornecidos
+     */
+    public static <T> void ensureListIsNotNullOrEmpty(List<T> inputList, Integer term, String errorMessage, Class<? extends RuntimeException> customException) {
+        validateCustomException(customException);
+        if (inputList == null || inputList.isEmpty()) {
+            throwException(term, errorMessage, customException);
+        }
+    }
+
+    /**
+     * Valida se uma {@code customException} especificada não é nula.
+     * <p>
+     * O método {@code validateCustomException} é um método estático e privado que recebe como parâmetro um objeto do tipo Class que
+     * é um subtipo de {@link RuntimeException}. O método então verifica se o parâmetro {@code customException} é nulo e, em caso afirmativo,
+     * lança uma {@link ValidationUtilsException} com uma mensagem de erro personalizada.
+     *
+     * @param customException objeto da subclasse de {@link RuntimeException} para ser validado
+     * @throws ValidationUtilsException se o {@code customException} for nulo
+     */
+    private static void validateCustomException(Class<? extends RuntimeException> customException) {
+        if (customException == null) {
+            throw new ValidationUtilsException(CUSTOM_EXCEPTION_ERROR);
         }
     }
 
@@ -67,6 +152,18 @@ public class ValidationUtils {
         return inputList;
     }
 
+    private static void throwException(Integer term, Class<? extends RuntimeException> runtimeExceptionClass) {
+        try {
+            Constructor<? extends RuntimeException> exceptionConstructor = runtimeExceptionClass.getConstructor(Integer.class);
+            var exception = exceptionConstructor.newInstance(term);
+            log.error(ExceptionDetails.getExceptionDetails(term).formatErrorMessage(), exception);
+            throw exception;
+        } catch (ReflectiveOperationException e) {
+            log.error(runtimeExceptionClass.getSimpleName(), e);
+            throw new ValidationUtilsException(runtimeExceptionClass.getSimpleName(), e);
+        }
+    }
+
     /**
      * Lança uma exceção customizada com a mensagem de erro fornecida.
      *
@@ -78,6 +175,33 @@ public class ValidationUtils {
         try {
             Constructor<? extends RuntimeException> exceptionConstructor = runtimeExceptionClass.getConstructor(String.class);
             var exception = exceptionConstructor.newInstance(message);
+            log.error(message, exception);
+            throw exception;
+        } catch (ReflectiveOperationException e) {
+            log.error(runtimeExceptionClass.getSimpleName(), e);
+            throw new ValidationUtilsException(runtimeExceptionClass.getSimpleName(), e);
+        }
+    }
+
+    /**
+     * Método que cria e lança exceções do tipo {@link RuntimeException} ou suas subclasses de acordo com os parâmetros fornecidos.
+     * Além disso, essa função gerencia a possibilidade de uma {@link ReflectiveOperationException} decorrente da tentativa de instanciar a exceção solicitada.
+     * Nesse caso, a função criará e lançará uma instância de {@link ValidationUtilsException} com a mensagem da {@link ReflectiveOperationException} original.
+     *
+     * @param term                  um Integer que é usado como parâmetro para a função de construtor da {@link RuntimeException} desejada.
+     * @param message               uma mensagem de String que é passada para a função de construtor da {@link RuntimeException} desejada
+     *                              e usada para geração de logs de erro.
+     * @param runtimeExceptionClass a classe de exceção Class<? extends RuntimeException> que é desejada para ser lançada.
+     *
+     *                              <p>Uso:</p>
+     *                              <code>throwException(100, "Valor inválido", IllegalArgumentException.class);</code>
+     * @throws ValidationUtilsException é lançado quando ocorre um {@code ReflectiveOperationException} na tentativa de construir a exceção desejada.
+     *                                  A {@code ValidationUtilsException} recebe o nome simples da classe de exceção desejada e a {@code ReflectiveOperationException} original.
+     */
+    private static void throwException(Integer term, String message, Class<? extends RuntimeException> runtimeExceptionClass) {
+        try {
+            Constructor<? extends RuntimeException> exceptionConstructor = runtimeExceptionClass.getConstructor(Integer.class, String.class);
+            var exception = exceptionConstructor.newInstance(term, message);
             log.error(message, exception);
             throw exception;
         } catch (ReflectiveOperationException e) {

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/AddressEntityMapperTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/AddressEntityMapperTest.java
@@ -1,7 +1,7 @@
 package diegosneves.github.conectardoacoes.adapters.rest.mapper;
 
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.AddressEntityFailuresException;
-import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
 import diegosneves.github.conectardoacoes.adapters.rest.model.AddressEntity;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Address;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,7 +9,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 class AddressEntityMapperTest {
@@ -54,7 +56,7 @@ class AddressEntityMapperTest {
         AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.addressEntityMapper.mapFrom(this.address));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(AddressEntityMapper.ADDRESS_CLASS.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(AddressEntityMapper.ADDRESS_CLASS.getSimpleName()), exception.getMessage());
     }
 
 }

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/AddressMapperTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/AddressMapperTest.java
@@ -1,7 +1,7 @@
 package diegosneves.github.conectardoacoes.adapters.rest.mapper;
 
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.AddressEntityFailuresException;
-import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
 import diegosneves.github.conectardoacoes.adapters.rest.model.AddressEntity;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Address;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,7 +9,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 class AddressMapperTest {
@@ -60,7 +62,7 @@ class AddressMapperTest {
         AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.addressMapper.mapFrom(this.addressEntity));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName()), exception.getMessage());
     }
 
     @Test
@@ -70,7 +72,7 @@ class AddressMapperTest {
         AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.addressMapper.mapFrom(this.addressEntity));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName()), exception.getMessage());
     }
 
     @Test
@@ -80,7 +82,7 @@ class AddressMapperTest {
         AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.addressMapper.mapFrom(this.addressEntity));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName()), exception.getMessage());
     }
 
     @Test
@@ -90,7 +92,7 @@ class AddressMapperTest {
         AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.addressMapper.mapFrom(this.addressEntity));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName()), exception.getMessage());
     }
 
     @Test
@@ -100,7 +102,7 @@ class AddressMapperTest {
         AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.addressMapper.mapFrom(this.addressEntity));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName()), exception.getMessage());
     }
 
     @Test
@@ -110,7 +112,7 @@ class AddressMapperTest {
         AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.addressMapper.mapFrom(this.addressEntity));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName()), exception.getMessage());
     }
 
     @Test
@@ -120,7 +122,7 @@ class AddressMapperTest {
         AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.addressMapper.mapFrom(this.addressEntity));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName()), exception.getMessage());
     }
 
     @Test
@@ -130,7 +132,7 @@ class AddressMapperTest {
         AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.addressMapper.mapFrom(this.addressEntity));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName()), exception.getMessage());
     }
 
     @Test
@@ -140,7 +142,7 @@ class AddressMapperTest {
         AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.addressMapper.mapFrom(this.addressEntity));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName()), exception.getMessage());
     }
 
     @Test
@@ -150,7 +152,7 @@ class AddressMapperTest {
         AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.addressMapper.mapFrom(this.addressEntity));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName()), exception.getMessage());
     }
 
     @Test
@@ -160,7 +162,7 @@ class AddressMapperTest {
         AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.addressMapper.mapFrom(this.addressEntity));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName()), exception.getMessage());
     }
 
     @Test
@@ -170,7 +172,7 @@ class AddressMapperTest {
         AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.addressMapper.mapFrom(this.addressEntity));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName()), exception.getMessage());
     }
 
     @Test
@@ -180,7 +182,7 @@ class AddressMapperTest {
         AddressEntityFailuresException exception = assertThrows(AddressEntityFailuresException.class, () -> this.addressMapper.mapFrom(this.addressEntity));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(AddressMapper.ADDRESS_ENTITY_TYPE.getSimpleName()), exception.getMessage());
     }
 
 }

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/DonationEntityMapperTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/DonationEntityMapperTest.java
@@ -1,6 +1,6 @@
 package diegosneves.github.conectardoacoes.adapters.rest.mapper;
 
-import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.ShelterEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.model.DonationEntity;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Donation;
@@ -9,7 +9,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 class DonationEntityMapperTest {
@@ -47,7 +49,7 @@ class DonationEntityMapperTest {
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.mapper.mapFrom(null));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(Donation.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(Donation.class.getSimpleName()), exception.getMessage());
     }
 
 }

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/DonationMapperTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/DonationMapperTest.java
@@ -1,6 +1,6 @@
 package diegosneves.github.conectardoacoes.adapters.rest.mapper;
 
-import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.ShelterEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.model.DonationEntity;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Donation;
@@ -12,7 +12,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 class DonationMapperTest {
@@ -64,7 +66,7 @@ class DonationMapperTest {
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.donationMapper.mapFrom(null));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(DonationEntity.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(DonationEntity.class.getSimpleName()), exception.getMessage());
     }
 
     @Test
@@ -74,7 +76,7 @@ class DonationMapperTest {
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.donationMapper.mapFrom(this.donationEntity));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(DonationEntity.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(DonationEntity.class.getSimpleName()), exception.getMessage());
         assertEquals(DonationRegisterFailureException.class, exception.getCause().getClass());
     }
 
@@ -86,7 +88,7 @@ class DonationMapperTest {
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.donationMapper.mapFrom(this.donationEntity));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(DonationEntity.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(DonationEntity.class.getSimpleName()), exception.getMessage());
         assertEquals(DonationRegisterFailureException.class, exception.getCause().getClass());
     }
 
@@ -97,7 +99,7 @@ class DonationMapperTest {
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.donationMapper.mapFrom(this.donationEntity));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(DonationEntity.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(DonationEntity.class.getSimpleName()), exception.getMessage());
         assertEquals(DonationRegisterFailureException.class, exception.getCause().getClass());
     }
 
@@ -108,7 +110,7 @@ class DonationMapperTest {
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.donationMapper.mapFrom(this.donationEntity));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(DonationEntity.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(DonationEntity.class.getSimpleName()), exception.getMessage());
         assertEquals(DonationRegisterFailureException.class, exception.getCause().getClass());
     }
 
@@ -119,7 +121,7 @@ class DonationMapperTest {
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.donationMapper.mapFrom(this.donationEntity));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(DonationEntity.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(DonationEntity.class.getSimpleName()), exception.getMessage());
         assertEquals(DonationRegisterFailureException.class, exception.getCause().getClass());
     }
 

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/ShelterEntityMapperTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/ShelterEntityMapperTest.java
@@ -1,7 +1,7 @@
 package diegosneves.github.conectardoacoes.adapters.rest.mapper;
 
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.enums.UserProfileType;
-import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.ShelterEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.UserEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.model.ShelterEntity;
@@ -156,7 +156,7 @@ class ShelterEntityMapperTest {
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.mapper.mapFrom(this.shelter));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(ShelterEntityMapper.SHELTER_CLASS.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(ShelterEntityMapper.SHELTER_CLASS.getSimpleName()), exception.getMessage());
     }
 
     @Test
@@ -170,7 +170,7 @@ class ShelterEntityMapperTest {
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.mapper.mapFrom(this.shelter));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(ShelterEntityMapper.SHELTER_CLASS.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(ShelterEntityMapper.SHELTER_CLASS.getSimpleName()), exception.getMessage());
         assertEquals(UserEntityFailuresException.class, exception.getCause().getClass());
     }
 

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/ShelterMapperTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/ShelterMapperTest.java
@@ -1,8 +1,8 @@
 package diegosneves.github.conectardoacoes.adapters.rest.mapper;
 
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.enums.UserProfileType;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.AddressEntityFailuresException;
-import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.ShelterEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.UserEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.model.AddressEntity;
@@ -25,7 +25,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 class ShelterMapperTest {
@@ -141,7 +146,7 @@ class ShelterMapperTest {
                 () -> this.shelterMapper.mapFrom(this.shelterEntity));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(ShelterEntity.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(ShelterEntity.class.getSimpleName()), exception.getMessage());
     }
 
     @ParameterizedTest
@@ -153,7 +158,7 @@ class ShelterMapperTest {
                 () -> this.shelterMapper.mapFrom(this.shelterEntity));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(ShelterEntity.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(ShelterEntity.class.getSimpleName()), exception.getMessage());
         assertEquals(ShelterCreationFailureException.class, exception.getCause().getClass());
     }
 
@@ -165,7 +170,7 @@ class ShelterMapperTest {
                 () -> this.shelterMapper.mapFrom(this.shelterEntity));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(ShelterEntity.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(ShelterEntity.class.getSimpleName()), exception.getMessage());
         assertEquals(ShelterCreationFailureException.class, exception.getCause().getClass());
     }
 
@@ -178,7 +183,7 @@ class ShelterMapperTest {
                 () -> this.shelterMapper.mapFrom(this.shelterEntity));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(ShelterEntity.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(ShelterEntity.class.getSimpleName()), exception.getMessage());
         assertEquals(ShelterCreationFailureException.class, exception.getCause().getClass());
     }
 
@@ -190,7 +195,7 @@ class ShelterMapperTest {
                 () -> this.shelterMapper.mapFrom(this.shelterEntity));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(ShelterEntity.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(ShelterEntity.class.getSimpleName()), exception.getMessage());
         assertEquals(ShelterCreationFailureException.class, exception.getCause().getClass());
     }
 
@@ -202,7 +207,7 @@ class ShelterMapperTest {
                 () -> this.shelterMapper.mapFrom(this.shelterEntity));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(ShelterEntity.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(ShelterEntity.class.getSimpleName()), exception.getMessage());
         assertEquals(AddressEntityFailuresException.class, exception.getCause().getClass());
     }
 
@@ -214,7 +219,7 @@ class ShelterMapperTest {
                 () -> this.shelterMapper.mapFrom(this.shelterEntity));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(ShelterEntity.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(ShelterEntity.class.getSimpleName()), exception.getMessage());
         assertEquals(UserEntityFailuresException.class, exception.getCause().getClass());
     }
 
@@ -226,7 +231,7 @@ class ShelterMapperTest {
                 () -> this.shelterMapper.mapFrom(this.shelterEntity));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(Donation.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(Donation.class.getSimpleName()), exception.getMessage());
         assertEquals(DonationRegisterFailureException.class, exception.getCause().getClass());
     }
 
@@ -238,7 +243,7 @@ class ShelterMapperTest {
                 () -> this.shelterMapper.mapFrom(this.shelterEntity));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(Donation.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(Donation.class.getSimpleName()), exception.getMessage());
         assertEquals(DonationRegisterFailureException.class, exception.getCause().getClass());
     }
 

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/UserEntityMapperTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/UserEntityMapperTest.java
@@ -1,5 +1,6 @@
 package diegosneves.github.conectardoacoes.adapters.rest.mapper;
 
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.enums.UserProfileType;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.ConstructorDefaultUndefinedException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
@@ -55,7 +56,7 @@ class UserEntityMapperTest {
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.userEntityMapper.mapFrom(this.user));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(UserEntityMapper.USER_CLASS.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(UserEntityMapper.USER_CLASS.getSimpleName()), exception.getMessage());
     }
 
     @Test
@@ -68,7 +69,7 @@ class UserEntityMapperTest {
             UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.userEntityMapper.mapFrom(this.user));
 
             assertNotNull(exception);
-            assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(UserEntityMapper.USER_CLASS.getSimpleName())), exception.getMessage());
+            assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(UserEntityMapper.USER_CLASS.getSimpleName()), exception.getMessage());
             assertEquals(ConstructorDefaultUndefinedException.class, exception.getCause().getClass());
         }
     }
@@ -83,7 +84,7 @@ class UserEntityMapperTest {
             UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.userEntityMapper.mapFrom(this.user));
 
             assertNotNull(exception);
-            assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(UserEntityMapper.USER_CLASS.getSimpleName())), exception.getMessage());
+            assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(UserEntityMapper.USER_CLASS.getSimpleName()), exception.getMessage());
             assertEquals(MapperFailureException.class, exception.getCause().getClass());
         }
     }

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/UserMapperTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/mapper/UserMapperTest.java
@@ -1,7 +1,7 @@
 package diegosneves.github.conectardoacoes.adapters.rest.mapper;
 
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.enums.UserProfileType;
-import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.UserEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.model.UserEntity;
 import diegosneves.github.conectardoacoes.core.domain.user.entity.UserContract;
@@ -59,7 +59,7 @@ class UserMapperTest {
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.userMapper.mapFrom(null));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName()), exception.getMessage());
     }
 
     @Test
@@ -69,7 +69,7 @@ class UserMapperTest {
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.userMapper.mapFrom(this.userEntity));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName()), exception.getMessage());
     }
 
     @Test
@@ -79,7 +79,7 @@ class UserMapperTest {
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.userMapper.mapFrom(this.userEntity));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName()), exception.getMessage());
         assertEquals(UserCreationFailureException.class, exception.getCause().getClass());
     }
 
@@ -90,7 +90,7 @@ class UserMapperTest {
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.userMapper.mapFrom(this.userEntity));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName()), exception.getMessage());
         assertEquals(UserCreationFailureException.class, exception.getCause().getClass());
     }
 
@@ -101,7 +101,7 @@ class UserMapperTest {
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.userMapper.mapFrom(this.userEntity));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName()), exception.getMessage());
         assertEquals(UserCreationFailureException.class, exception.getCause().getClass());
     }
 
@@ -112,7 +112,7 @@ class UserMapperTest {
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.userMapper.mapFrom(this.userEntity));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName()), exception.getMessage());
         assertEquals(UserCreationFailureException.class, exception.getCause().getClass());
     }
 
@@ -123,7 +123,7 @@ class UserMapperTest {
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.userMapper.mapFrom(this.userEntity));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName()), exception.getMessage());
         assertEquals(UserCreationFailureException.class, exception.getCause().getClass());
     }
 
@@ -134,7 +134,7 @@ class UserMapperTest {
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.userMapper.mapFrom(this.userEntity));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName()), exception.getMessage());
         assertEquals(UserCreationFailureException.class, exception.getCause().getClass());
     }
 
@@ -145,7 +145,7 @@ class UserMapperTest {
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.userMapper.mapFrom(this.userEntity));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName()), exception.getMessage());
         assertEquals(UserCreationFailureException.class, exception.getCause().getClass());
     }
 
@@ -157,7 +157,7 @@ class UserMapperTest {
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.userMapper.mapFrom(this.userEntity));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(UserMapper.USER_ENTITY_CLASS.getSimpleName()), exception.getMessage());
         assertEquals(UserCreationFailureException.class, exception.getCause().getClass());
     }
 

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/repository/ShelterRepositoryIntegrationTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/repository/ShelterRepositoryIntegrationTest.java
@@ -1,6 +1,6 @@
 package diegosneves.github.conectardoacoes.adapters.rest.repository;
 
-import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.ShelterEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.mapper.AddressEntityMapper;
 import diegosneves.github.conectardoacoes.adapters.rest.mapper.DonationEntityMapper;
@@ -186,7 +186,7 @@ class ShelterRepositoryIntegrationTest {
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.shelterRepository.findEntityById(null));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterRepository.INVALID_ID_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterRepository.INVALID_ID_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -200,21 +200,22 @@ class ShelterRepositoryIntegrationTest {
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.shelterRepository.findEntityById(""));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterRepository.INVALID_ID_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterRepository.INVALID_ID_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
     @Test
     void shouldThrowExceptionAndHaveCauseWhenFindingEntityByIdGivenInvalidId() {
+        String invalidId = "invalidId";
         persistEntity(new AddressEntityMapper(), this.address);
         persistEntity(new UserEntityMapper(), this.user);
         persistEntity(new DonationEntityMapper(), this.donation);
         persistEntity(new ShelterEntityMapper(), this.shelter);
 
-        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.shelterRepository.findEntityById("null"));
+        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.shelterRepository.findEntityById(invalidId));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterRepository.INVALID_ID_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterRepository.INVALID_UUID_FORMAT_MESSAGE).formatErrorMessage(invalidId), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(UuidUtilsException.class, exception.getCause().getClass());
     }
@@ -266,7 +267,7 @@ class ShelterRepositoryIntegrationTest {
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.shelterRepository.retrieveAll());
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(ShelterEntity.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(ShelterEntity.class.getSimpleName()), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(ShelterCreationFailureException.class, exception.getCause().getClass());
     }
@@ -347,7 +348,7 @@ class ShelterRepositoryIntegrationTest {
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.shelterRepository.persist(null));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterRepository.SHELTER_ERROR_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterRepository.SHELTER_ERROR_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -383,7 +384,7 @@ class ShelterRepositoryIntegrationTest {
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.shelterRepository.deleteEntityById(""));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterRepository.INVALID_ID_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterRepository.INVALID_ID_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -393,17 +394,18 @@ class ShelterRepositoryIntegrationTest {
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.shelterRepository.deleteEntityById(null));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterRepository.INVALID_ID_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterRepository.INVALID_ID_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
     @Test
     void shouldThrowExceptionWhenIdIsInvalid() {
+        String invalidId = "invalidId";
 
-        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.shelterRepository.deleteEntityById("null"));
+        ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.shelterRepository.deleteEntityById(invalidId));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterRepository.INVALID_ID_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterRepository.INVALID_UUID_FORMAT_MESSAGE).formatErrorMessage(invalidId), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(UuidUtilsException.class, exception.getCause().getClass());
     }

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/repository/UserRepositoryTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/repository/UserRepositoryTest.java
@@ -1,7 +1,7 @@
 package diegosneves.github.conectardoacoes.adapters.rest.repository;
 
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.enums.UserProfileType;
-import diegosneves.github.conectardoacoes.adapters.rest.exception.MapperFailureException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.UserEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.mapper.MapperStrategy;
 import diegosneves.github.conectardoacoes.adapters.rest.mapper.UserEntityMapper;
@@ -114,10 +114,11 @@ class UserRepositoryTest {
 
     @Test
     void verifyExceptionThrownWhenInvalidIdIsProviedToFindEntityById() {
-        UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.repository.findEntityById("USER_ID"));
+        String invalidId = "invalidId";
+        UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.repository.findEntityById(invalidId));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserRepository.USER_ID_ERROR_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserRepository.INVALID_UUID_FORMAT_MESSAGE).formatErrorMessage(invalidId), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(UuidUtilsException.class, exception.getCause().getClass());
     }
@@ -128,7 +129,7 @@ class UserRepositoryTest {
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.repository.findEntityById(value));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserRepository.USER_ID_ERROR_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserRepository.INVALID_ID_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -137,7 +138,7 @@ class UserRepositoryTest {
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.repository.findEntityById(null));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserRepository.USER_ID_ERROR_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserRepository.INVALID_ID_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -181,7 +182,7 @@ class UserRepositoryTest {
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.repository.retrieveAll());
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(MapperFailureException.ERROR.formatErrorMessage(UserEntity.class.getSimpleName())), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(MapperStrategy.CLASS_MAPPING_FAILURE).formatErrorMessage(UserEntity.class.getSimpleName()), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(UserCreationFailureException.class, exception.getCause().getClass());
     }
@@ -203,7 +204,7 @@ class UserRepositoryTest {
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.repository.persist(null));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserRepository.REQUIRED_USER_ERROR_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserRepository.REQUIRED_USER_ERROR_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -233,7 +234,7 @@ class UserRepositoryTest {
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.repository.deleteEntityById(null));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserRepository.USER_ID_ERROR_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserRepository.INVALID_ID_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -244,17 +245,18 @@ class UserRepositoryTest {
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.repository.deleteEntityById(id));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserRepository.USER_ID_ERROR_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserRepository.INVALID_ID_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
     @Test
     void shouldThrowExceptionWhenDeletingEntityWithNullIdAndCatchUuidException() {
+        String invalidId = "777e9377";
 
-        UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.repository.deleteEntityById("null"));
+        UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () -> this.repository.deleteEntityById(invalidId));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserRepository.USER_ID_ERROR_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserRepository.INVALID_UUID_FORMAT_MESSAGE).formatErrorMessage(invalidId), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(UuidUtilsException.class, exception.getCause().getClass());
     }

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/AddressEntityServiceImplTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/AddressEntityServiceImplTest.java
@@ -1,6 +1,7 @@
 package diegosneves.github.conectardoacoes.adapters.rest.service.impl;
 
 import diegosneves.github.conectardoacoes.adapters.rest.dto.AddressDTO;
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.AddressEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.mapper.AddressEntityMapper;
 import diegosneves.github.conectardoacoes.adapters.rest.mapper.BuilderMapper;
@@ -104,7 +105,7 @@ class AddressEntityServiceImplTest {
             verify(this.repository, never()).save(any(AddressEntity.class));
 
             assertNotNull(exception);
-            assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ERROR_MAPPING_ADDRESS), exception.getMessage());
+            assertEquals(ExceptionDetails.getExceptionDetails(AddressEntityServiceImpl.ERROR_MAPPING_ADDRESS).formatErrorMessage(), exception.getMessage());
             assertNotNull(exception.getCause());
             assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
         }
@@ -119,7 +120,7 @@ class AddressEntityServiceImplTest {
         verify(this.repository, never()).save(any(AddressEntity.class));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -132,7 +133,7 @@ class AddressEntityServiceImplTest {
         verify(this.repository, never()).save(any(AddressEntity.class));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
     }
@@ -147,7 +148,7 @@ class AddressEntityServiceImplTest {
         verify(this.repository, never()).save(any(AddressEntity.class));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
     }
@@ -161,7 +162,7 @@ class AddressEntityServiceImplTest {
         verify(this.repository, never()).save(any(AddressEntity.class));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
     }
@@ -176,7 +177,7 @@ class AddressEntityServiceImplTest {
         verify(this.repository, never()).save(any(AddressEntity.class));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
     }
@@ -190,7 +191,7 @@ class AddressEntityServiceImplTest {
         verify(this.repository, never()).save(any(AddressEntity.class));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
     }
@@ -205,7 +206,7 @@ class AddressEntityServiceImplTest {
         verify(this.repository, never()).save(any(AddressEntity.class));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
     }
@@ -219,7 +220,7 @@ class AddressEntityServiceImplTest {
         verify(this.repository, never()).save(any(AddressEntity.class));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
     }
@@ -234,7 +235,7 @@ class AddressEntityServiceImplTest {
         verify(this.repository, never()).save(any(AddressEntity.class));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
     }
@@ -248,7 +249,7 @@ class AddressEntityServiceImplTest {
         verify(this.repository, never()).save(any(AddressEntity.class));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
     }
@@ -263,7 +264,7 @@ class AddressEntityServiceImplTest {
         verify(this.repository, never()).save(any(AddressEntity.class));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
     }
@@ -277,7 +278,7 @@ class AddressEntityServiceImplTest {
         verify(this.repository, never()).save(any(AddressEntity.class));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
     }
@@ -292,7 +293,7 @@ class AddressEntityServiceImplTest {
         verify(this.repository, never()).save(any(AddressEntity.class));
 
         assertNotNull(exception);
-        assertEquals(AddressEntityFailuresException.ERROR.formatErrorMessage(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(AddressEntityServiceImpl.ADDRESS_CREATION_ERROR).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(AddressCreationFailureException.class, exception.getCause().getClass());
     }

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/DonationEntityServiceImplTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/DonationEntityServiceImplTest.java
@@ -104,7 +104,7 @@ class DonationEntityServiceImplTest {
         verify(this.repository, never()).save(any(DonationEntity.class));
 
         assertNotNull(exception);
-        assertEquals(DonationEntityFailuresException.ERROR.formatErrorMessage(DonationEntityServiceImpl.INVALID_DONATION_INFO_ERROR), exception.getMessage());
+        assertEquals(exception.getErrorDetails().formatErrorMessage(DonationEntityServiceImpl.INVALID_DONATION_INFO_ERROR), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -119,7 +119,7 @@ class DonationEntityServiceImplTest {
         verify(this.repository, never()).save(any(DonationEntity.class));
 
         assertNotNull(exception);
-        assertEquals(DonationEntityFailuresException.ERROR.formatErrorMessage(DonationEntityServiceImpl.DONATION_CREATION_FAILURE), exception.getMessage());
+        assertEquals(exception.getErrorDetails().formatErrorMessage(DonationEntityServiceImpl.DONATION_CREATION_FAILURE), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(DonationRegisterFailureException.class, exception.getCause().getClass());
     }
@@ -134,7 +134,7 @@ class DonationEntityServiceImplTest {
         verify(this.repository, never()).save(any(DonationEntity.class));
 
         assertNotNull(exception);
-        assertEquals(DonationEntityFailuresException.ERROR.formatErrorMessage(DonationEntityServiceImpl.DONATION_CREATION_FAILURE), exception.getMessage());
+        assertEquals(exception.getErrorDetails().formatErrorMessage(DonationEntityServiceImpl.DONATION_CREATION_FAILURE), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(DonationRegisterFailureException.class, exception.getCause().getClass());
     }

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/ShelterEntityServiceImplTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/ShelterEntityServiceImplTest.java
@@ -2,6 +2,7 @@ package diegosneves.github.conectardoacoes.adapters.rest.service.impl;
 
 import diegosneves.github.conectardoacoes.adapters.rest.dto.AddressDTO;
 import diegosneves.github.conectardoacoes.adapters.rest.dto.DonationDTO;
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.enums.UserProfileType;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.AddressEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.ShelterEntityFailuresException;
@@ -186,7 +187,7 @@ class ShelterEntityServiceImplTest {
         verify(this.userEntityService, times(1)).searchUserByEmail(USER_EMAIL);
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.SHELTER_CREATION_ERROR_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterEntityServiceImpl.SHELTER_CREATION_ERROR_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(ShelterCreationFailureException.class, exception.getCause().getClass());
     }
@@ -202,7 +203,7 @@ class ShelterEntityServiceImplTest {
         verify(this.userEntityService, times(1)).searchUserByEmail(USER_EMAIL);
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.SHELTER_CREATION_ERROR_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterEntityServiceImpl.SHELTER_CREATION_ERROR_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(ShelterCreationFailureException.class, exception.getCause().getClass());
     }
@@ -219,7 +220,7 @@ class ShelterEntityServiceImplTest {
         verify(this.repository, never()).persist(any(ShelterContract.class));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.USER_RESPONSIBLE_EMAIL_NOT_FOUND_ERROR), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterEntityServiceImpl.USER_RESPONSIBLE_EMAIL_NOT_FOUND_ERROR).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(UserEntityFailuresException.class, exception.getCause().getClass());
     }
@@ -234,7 +235,7 @@ class ShelterEntityServiceImplTest {
         verify(this.repository, never()).persist(any(ShelterContract.class));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.USER_RESPONSIBLE_EMAIL_NOT_FOUND_ERROR), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterEntityServiceImpl.USER_RESPONSIBLE_EMAIL_NOT_FOUND_ERROR).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(UserEntityFailuresException.class, exception.getCause().getClass());
     }
@@ -256,7 +257,7 @@ class ShelterEntityServiceImplTest {
         verify(this.repository, never()).persist(any(ShelterContract.class));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.SHELTER_CREATION_ERROR_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterEntityServiceImpl.SHELTER_CREATION_ERROR_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(AddressEntityFailuresException.class, exception.getCause().getClass());
     }
@@ -270,7 +271,7 @@ class ShelterEntityServiceImplTest {
         verify(this.repository, never()).persist(any(ShelterContract.class));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.REQUEST_VALIDATION_ERROR_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterEntityServiceImpl.REQUEST_VALIDATION_ERROR_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -290,7 +291,7 @@ class ShelterEntityServiceImplTest {
             verify(this.repository, times(1)).persist(any(ShelterContract.class));
 
             assertNotNull(exception);
-            assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.SHELTER_CREATION_ERROR_MESSAGE), exception.getMessage());
+            assertEquals(ExceptionDetails.getExceptionDetails(ShelterEntityServiceImpl.SHELTER_CREATION_ERROR_MESSAGE).formatErrorMessage(), exception.getMessage());
             assertNotNull(exception.getCause());
             assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
         }
@@ -308,7 +309,7 @@ class ShelterEntityServiceImplTest {
         verify(this.userEntityService, times(1)).searchUserByEmail(USER_EMAIL);
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.RESPONSIBLE_USER_PROFILE_INVALID), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterEntityServiceImpl.RESPONSIBLE_USER_PROFILE_INVALID).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -326,7 +327,7 @@ class ShelterEntityServiceImplTest {
         verify(this.repository, times(1)).findShelterEntitiesByResponsibleUser_Email(USER_EMAIL);
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.RESPONSIBLE_USER_ALREADY_IN_USE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterEntityServiceImpl.RESPONSIBLE_USER_ALREADY_IN_USE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -389,7 +390,7 @@ class ShelterEntityServiceImplTest {
         ShelterEntityFailuresException exception = assertThrows(ShelterEntityFailuresException.class, () -> this.service.receiveDonation(null));
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.DONATION_VALIDATION_ERROR), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterEntityServiceImpl.DONATION_VALIDATION_ERROR).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -408,7 +409,7 @@ class ShelterEntityServiceImplTest {
         verify(this.repository, times(1)).findShelterEntitiesByResponsibleUser_Email(USER_EMAIL);
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.EMPTY_DONATION_LIST), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterEntityServiceImpl.EMPTY_DONATION_LIST).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -427,7 +428,7 @@ class ShelterEntityServiceImplTest {
         verify(this.repository, times(1)).findShelterEntitiesByResponsibleUser_Email(USER_EMAIL);
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.EMPTY_DONATION_LIST), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterEntityServiceImpl.EMPTY_DONATION_LIST).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -444,7 +445,7 @@ class ShelterEntityServiceImplTest {
         verify(this.repository, times(1)).findShelterEntitiesByResponsibleUser_Email(USER_EMAIL);
 
         assertNotNull(exception);
-        assertEquals(ShelterEntityFailuresException.ERROR.formatErrorMessage(ShelterEntityServiceImpl.RESPONSIBLE_EMAIL_NOT_ASSOCIATED_WITH_SHELTER), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(ShelterEntityServiceImpl.RESPONSIBLE_EMAIL_NOT_ASSOCIATED_WITH_SHELTER).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/UserEntityServiceImplTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/UserEntityServiceImplTest.java
@@ -1,5 +1,6 @@
 package diegosneves.github.conectardoacoes.adapters.rest.service.impl;
 
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
 import diegosneves.github.conectardoacoes.adapters.rest.enums.UserProfileType;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.UserEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.model.UserEntity;
@@ -23,7 +24,11 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
@@ -96,7 +101,7 @@ class UserEntityServiceImplTest {
         verify(this.userRepository, times(1)).findByEmail(anyString());
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(String.format(UserEntityServiceImpl.EMAIL_NOT_FOUND_ERROR_MESSAGE, email)), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserEntityServiceImpl.EMAIL_NOT_FOUND_ERROR_MESSAGE).formatErrorMessage(email), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -110,7 +115,7 @@ class UserEntityServiceImplTest {
         verify(this.userRepository, never()).findByEmail(anyString());
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserEntityServiceImpl.INVALID_EMAIL_ERROR_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserEntityServiceImpl.INVALID_EMAIL_ERROR_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -123,7 +128,7 @@ class UserEntityServiceImplTest {
         verify(this.userRepository, never()).findByEmail(anyString());
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserEntityServiceImpl.INVALID_EMAIL_ERROR_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserEntityServiceImpl.INVALID_EMAIL_ERROR_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -162,7 +167,7 @@ class UserEntityServiceImplTest {
         verify(this.userRepository, never()).save(any(UserEntity.class));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserEntityServiceImpl.EMAIL_ALREADY_IN_USE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserEntityServiceImpl.EMAIL_ALREADY_IN_USE).formatErrorMessage(USER_EMAIL), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -177,7 +182,7 @@ class UserEntityServiceImplTest {
         verify(this.userRepository, never()).save(any(UserEntity.class));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserEntityServiceImpl.INVALID_EMAIL_ERROR_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserEntityServiceImpl.INVALID_EMAIL_ERROR_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -193,7 +198,7 @@ class UserEntityServiceImplTest {
         verify(this.userRepository, never()).save(any(UserEntity.class));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserEntityServiceImpl.INVALID_EMAIL_ERROR_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserEntityServiceImpl.INVALID_EMAIL_ERROR_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -208,7 +213,7 @@ class UserEntityServiceImplTest {
         verify(this.userRepository, never()).save(any(UserEntity.class));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserEntityServiceImpl.USER_CREATION_FAILURE_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserEntityServiceImpl.USER_CREATION_FAILURE_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(UserCreationFailureException.class, exception.getCause().getClass());
     }
@@ -225,7 +230,7 @@ class UserEntityServiceImplTest {
         verify(this.userRepository, never()).save(any(UserEntity.class));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserEntityServiceImpl.USER_CREATION_FAILURE_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserEntityServiceImpl.USER_CREATION_FAILURE_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(UserCreationFailureException.class, exception.getCause().getClass());
     }
@@ -241,7 +246,7 @@ class UserEntityServiceImplTest {
         verify(this.userRepository, never()).save(any(UserEntity.class));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserEntityServiceImpl.USER_CREATION_FAILURE_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserEntityServiceImpl.USER_CREATION_FAILURE_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(UserCreationFailureException.class, exception.getCause().getClass());
     }
@@ -258,7 +263,7 @@ class UserEntityServiceImplTest {
         verify(this.userRepository, never()).save(any(UserEntity.class));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserEntityServiceImpl.USER_CREATION_FAILURE_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserEntityServiceImpl.USER_CREATION_FAILURE_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNotNull(exception.getCause());
         assertEquals(UserCreationFailureException.class, exception.getCause().getClass());
     }
@@ -274,7 +279,7 @@ class UserEntityServiceImplTest {
         verify(this.userRepository, never()).save(any(UserEntity.class));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserEntityServiceImpl.USER_PROFILE_VALIDATION_FAILURE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserEntityServiceImpl.USER_PROFILE_VALIDATION_FAILURE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 
@@ -287,7 +292,7 @@ class UserEntityServiceImplTest {
         verify(this.userRepository, never()).save(any(UserEntity.class));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(UserEntityServiceImpl.MISSING_USER_ENTITY_REQUEST_ERROR_MESSAGE), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserEntityServiceImpl.MISSING_USER_ENTITY_REQUEST_ERROR_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
     }
 

--- a/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/UserEntityServiceImplTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/UserEntityServiceImplTest.java
@@ -302,8 +302,7 @@ class UserEntityServiceImplTest {
                 this.userEntityService.findUserByEmail(email));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(
-                String.format(UserEntityServiceImpl.EMAIL_NOT_FOUND_ERROR_MESSAGE, email)), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserEntityServiceImpl.EMAIL_NOT_FOUND_ERROR_MESSAGE).formatErrorMessage(email), exception.getMessage());
         assertNull(exception.getCause());
 
     }
@@ -311,14 +310,12 @@ class UserEntityServiceImplTest {
     @Test
     void shouldThrowUserEntityFailuresExceptionWhenTheEmailPassIsNull(){
 
-        String email = null;
 
         UserEntityFailuresException exception = assertThrows(UserEntityFailuresException.class, () ->
-                this.userEntityService.findUserByEmail(email));
+                this.userEntityService.findUserByEmail(null));
 
         assertNotNull(exception);
-        assertEquals(UserEntityFailuresException.ERROR.formatErrorMessage(
-                String.format(UserEntityServiceImpl.EMAIL_NOT_FOUND_ERROR_MESSAGE, email)), exception.getMessage());
+        assertEquals(ExceptionDetails.getExceptionDetails(UserEntityServiceImpl.INVALID_EMAIL_ERROR_MESSAGE).formatErrorMessage(), exception.getMessage());
         assertNull(exception.getCause());
 
     }
@@ -327,7 +324,9 @@ class UserEntityServiceImplTest {
     void testFindByEmail_WhenEmailIsValid_ShouldReturnUserEntityCreatedResponseObject(){
 
         when(userRepository.findByEmail(USER_EMAIL)).thenReturn(Optional.ofNullable(this.userEntity));
+
         UserEntityCreatedResponse userByEmail = userEntityService.findUserByEmail(USER_EMAIL);
+
         assertNotNull(userByEmail);
         assertEquals(USER_ID, userByEmail.getId());
         assertEquals(USERNAME, userByEmail.getUserName());


### PR DESCRIPTION
# Solicitação de Pull Request

## Status

- [x] In Progress
- [ ] Ready to Merging

## Tipo

- [ ] Release
- [ ] Feature
- [x] Technical Debt
- [ ] Fix
- [ ] Test
- [ ] Refactor
- [ ] Documentation
- [ ] Performance

## Descrição

**Commit** c9f30632bc67732f04a84760835bb55fc68db1ff:

Este commit adiciona classes de exceção personalizadas e atualizações enum `ExceptionDetails`.

**Arquivos Alterados:** `ExceptionDetails.java`, `CustomException.java`, `DetailsFailureException.java`

**Alterações:**

- A enumeração `ExceptionDetails.java` foi expandida para incluir novos códigos de termos e mensagens correspondentes a erros e exceções específicas. Um novo método também foi adicionado para recuperar detalhes de exceção com base em um termo.
- Duas novas classes de exceção personalizadas, `CustomException.java` e `DetailsFailureException.java`, foram criadas. Elas fornecem manipulação de erros e exceções mais robusta e permitem o rastreamento de erros mais refinado.

**Nota:** A principal ênfase deste commit é melhorar o gerenciamento de erros e exceções na aplicação. Ao personalizar a manipulação de erros, o aplicativo pode fornecer feedback mais útil em casos de falha e pode rastrear melhor onde e por que essas falhas estão ocorrendo.

---

**Commit** 3d8aa4e9c41d775cd99bc05a7e943f5782e2b943:

Este commit atualiza as classes de exceção para estenderem `CustomException`. Também modifica suas estruturas para utilizar termos em seus construtores. Esses termos são usados para buscar os detalhes correspondentes da exceção lançada. Além disso, o processo de validação de exceções personalizadas foram reformulados em `ValidationUtils`.

**Arquivos Alterados:** `AddressEntityFailuresException.java`, `ConstructorDefaultUndefinedException.java`, `DonationEntityFailuresException.java`, `MapperFailureException.java`, entre outros.

**Alterações:**

- As classes de exceção como `AddressEntityFailuresException.java`, `ConstructorDefaultUndefinedException.java`, `DonationEntityFailuresException.java` e `MapperFailureException.java` foram atualizadas para estender `CustomException` em vez de `RuntimeException`.
- Os construtores nestas classes de exceção agora requerem um integer 'termo' que é usado para buscar informações detalhadas sobre a exceção.
- Além da mensagem de exceção e Throwable 'cause', os construtores nas classes de exceção também levam um termo que é usado para buscar os detalhes da exceção.
  
**Nota:** A principal ênfase deste commit é aprimorar a manipulação personalizada de exceções fornecendo termos específicos. Os termos permitem recuperar detalhes precisos de exceção para rastreabilidade aprimorada.

---

**Commit** e2f253b88508be00afcee028855bf1a43baa6f81:

Este commit inclui a constante CLASS_MAPPING_FAILURE na interface `MapperStrategy` e na classe `BuilderMapper`. Este valor é utilizado para melhorar as mensagens de erro quando um erro de mapeamento de classe ocorre, tornando-as mais informativas e úteis para rastrear o problema.

**Arquivos Alterados:** `BuilderMapper.java`, `MapperStrategy.java`

**Alterações:**

- A constante `CLASS_MAPPING_FAILURE` foi adicionada à interface `MapperStrategy` e à classe `BuilderMapper`.
- No construtor da classe `BuilderMapper`, a constante `CLASS_MAPPING_FAILURE` é utilizada nas mensagens de exceção para `ConstructorDefaultUndefinedException` e `MapperFailureException`.

**Nota:** A principal ênfase desta confirmação é melhorar a rastreabilidade dos erros de mapeamento de classe, fornecendo mensagens de erro mais informativas.

---

**Commit** b77edf4fd52a59bd3492cdf5e245c6e60326a597:

Este commit atualiza o tratamento de exceções no mapeamento de entidade de endereço. Substitui `MapperFailureException` por `ExceptionDetails` e faz alterações correspondentes no código para tratar as exceções de forma mais consistente. As mensagens de erro também foram atualizadas para utilizar códigos de erro em vez de strings literais. Todos os testes de unidade afetados foram atualizados de acordo.

**Arquivos Alterados:** `AddressEntityMapper.java`, `AddressMapper.java`, `AddressEntityServiceImpl.java`, `AddressEntityMapperTest.java`, `AddressMapperTest.java`

**Alterações:**

- Substituição da exceção `MapperFailureException` por `ExceptionDetails` para tratamento de exceções mais consistente.
- Atualização das mensagens de erro para utilizar códigos de erro em vez de strings literais.
- Atualização de todos os testes de unidade afetados pelas mudanças.
  
**Nota:** A principal ênfase desta confirmação é aprimorar o tratamento de exceções, tornando-o mais consistente e informativo.

---

**Commit** 4bfba94e14fa15eab72802b934be48d784512f61:

Este commit atualiza a manipulação de exceções nos mapeadores de doação e nos testes relacionados para fornecer mensagens de erro mais precisas. As dependências desnecessárias foram removidas e as mensagens de erro foram atualizadas para usar os detalhes específicos da exceção. Esses ajustes ajudam a rastrear e resolver erros mais eficientemente.

**Arquivos Alterados:** `DonationEntityMapper.java`, `DonationMapper.java`, `DonationEntityServiceImpl.java`, `DonationEntityMapperTest.java`, `DonationMapperTest.java`

**Alterações:**

- Substituição do tratamento de exceção `MapperFailureException` por chamadas diretas ao método `mapFrom`.
- As mensagens de erro foram atualizadas para usar os detalhes específicos da exceção.
- Inclusão de uma lógica que garante que a entidade a ser persistida não seja nula no arquivo `DonationEntityServiceImpl.java`.

**Nota:** A principal ênfase desta confirmação é aprimorar o tratamento de exceções para fornecer mensagens de erro mais precisas.

---

**Commit** 73d60cae3828d21657858bb8462b8c4877500959:

Este commit substitui as mensagens de erro dinâmicas por códigos de erro em várias classes e testes relacionados às exceções. Esta alteração facilita a rastreabilidade e a interpretação de erros, pois eles são agora identificados com códigos consistentes em vez de mensagens de texto.

**Arquivos Alterados:** `ShelterEntityMapper.java`, `ShelterMapper.java`, `ShelterRepository.java`, `ShelterEntityServiceImpl.java`, `ShelterEntityMapperTest.java`

**Alterações:**

- As mensagens de erro em várias classes e testes foram substituídas por códigos específicos.
- Removido o tratamento de exceção `MapperFailureException` em `ShelterEntityMapper.java` e `ShelterMapper.java`, substituindo por chamadas diretas ao método class-specific `mapFrom`.
- As constantes de mensagem de erro no `ShelterRepository.java` e `ShelterEntityServiceImpl.java` foram alteradas para códigos de erro correspondentes.
- Testes foram atualizados para verificar as condições de erro apropriadas.

**Nota:** A principal ênfase desta confirmação é aprimorar a rastreabilidade e interpretação de erros usando códigos de erro em vez de mensagens de texto.

---

**Commit** 5a6f3e5d52a558ba53aff0fd80413e99f30eeffc:

Este commit atualiza validações e tratamento de exceção com detalhes de exceção. As mensagens de erro em várias classes e testes foram substituídas por códigos de erro, incluindo nas classes `UserEntityMapper`, `UserMapper` e `UserRepository`.

**Arquivos Alterados:** `UserEntityMapper.java`, `UserMapper.java`, `UserRepository.java`, `UserEntityServiceImpl.java`, `UserEntityMapperTest.java`

**Alterações:**

- As mensagens de erro em várias classes e testes foram substituídas por códigos específicos.
- A lógica de validação para as classes `UserEntityMapper`, `UserMapper` e `UserRepository` foi atualizada para usar a nova classe `ExceptionDetails` no mapeamento e nos serviços de teste.
- Também foram ajustadas validações para as classes `UserEntityMapper`, `UserMapper` e `UserRepository` para melhorar a precisão na verificação de dados.

**Nota:** A principal ênfase desta confirmação é aprimorar a rastreabilidade e interpretação de erros usando detalhes de exceção em vez de mensagens de texto.

---

**Commit** e2a7418514e639aa29b060f5055ed07c70faf500:

Este commit adiciona comentários de documentação detalhados para a classe CustomException e seus construtores. Além disso, há uma refatoração do tratamento de exceções personalizadas no ControllerExceptionHandler, simplificando o processo para lidar apenas com a classe base CustomException em vez de várias subclasses específicas. Esta mudança torna o código mais genérico e fácil de manter.

**Arquivos Alterados:** 

- `ControllerExceptionHandler.java`
- `CustomException.java`

**Alterações:**

- Adição de documentação de comentários detalhada para a classe `CustomException` e seus construtores.
- Refatoração do tratamento de exceções personalizadas no `ControllerExceptionHandler` para lidar apenas com a classe base `CustomException`.
- O tratador de exceções específico para `ConstructorDefaultUndefinedException`, `ShelterEntityFailuresException`, `AddressEntityFailuresException`, `MapperFailureException`, `UserEntityFailuresException`, `DonationEntityFailuresException` foram removidos.
- Adicionada uma nova função tratadora de exceções específica para `CustomException`, que captura a exceção e processa a criação de um `ExceptionDTO`, bem como um `ResponseEntity` contendo os detalhes de erro da exceção.

**Nota:** A principal ênfase desta confirmação é melhorar a documentação detalhada para a classe `CustomException` e simplificar o tratamento de exceções personalizadas no ControllerExceptionHandler para lidar apenas com a classe base `CustomException`, tornando o código mais genérico e fácil de manter.

---

**Commit** 8130c3d18bda82296864cb18675db7f6161137da:

Este commit refatora os métodos de teste e implementação na classe `UserEntityServiceImpl`. Isso inclui a simplificação dos métodos de teste em `UserEntityServiceImplTest` para reduzir redundâncias. Além disso, mudanças significativas foram feitas no arquivo `UserEntityServiceImpl`, principalmente na maneira como o `UserEntityMapper` é utilizado. O objetivo desta refatoração é proporcionar um código mais enxuto e legível.

**Arquivos Alterados:** `UserEntityServiceImpl.java`, `UserEntityServiceImplTest.java`

**Alterações:**

- Os métodos de teste em `UserEntityServiceImplTest` foram simplificados.
- Um novo método, `getUserEntityMapper()`, foi adicionado recentemente em `UserEntityServiceImpl`.
- O método `findUserByEmail` em `UserEntityServiceImpl` foi refatorado para utilizar `BuilderMapper.mapTo()` e `getUserEntityMapper()`.
- O método `createUserEntityFromCreationRequest` em `UserEntityServiceImpl` também foi refatorado para usar `getUserEntityMapper()`.

**Nota:** A ênfase principal deste commit é a redução de redundâncias no código de teste e a refatoração de como o `UserEntityMapper` é empregado na `UserEntityServiceImpl`.
