### PR TITLE
feat/i69 :art: [CORE/REST] - Criação da Interface AddressServiceContract e Adaptação do AddressEntityServiceImpl

### DIFF
--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/AddressEntityServiceImpl.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/AddressEntityServiceImpl.java
@@ -8,8 +8,9 @@ import diegosneves.github.conectardoacoes.adapters.rest.model.AddressEntity;
 import diegosneves.github.conectardoacoes.adapters.rest.repository.AddressRepository;
 import diegosneves.github.conectardoacoes.adapters.rest.service.AddressEntityService;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Address;
-import diegosneves.github.conectardoacoes.core.domain.shelter.factory.AddressFactory;
 import diegosneves.github.conectardoacoes.core.exception.AddressCreationFailureException;
+import diegosneves.github.conectardoacoes.core.service.AddressService;
+import diegosneves.github.conectardoacoes.core.service.AddressServiceContract;
 import diegosneves.github.conectardoacoes.core.utils.ValidationUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,7 +23,7 @@ import org.springframework.stereotype.Service;
  * Ao iniciar, o serviço valida se o objeto endereço não é nulo nem vazio.
  * Em caso de falha na validação, é lançada uma exceção {@link AddressEntityFailuresException} com a mensagem específica.
  * <p>
- * Depois, é criada uma nova instância de {@link Address} usando {@link AddressFactory}, que pode gerar exceções durante a criação,
+ * Depois, é criada uma nova instância de {@link Address} usando {@link AddressServiceContract}, que pode gerar exceções durante a criação,
  * as quais são capturadas e tratadas, emitindo novas {@link AddressEntityFailuresException} em caso de erros.
  * <p>
  * Por fim, o serviço faz uso do objeto {@link Address} criado para armazená-lo no repositório correspondente,
@@ -52,9 +53,11 @@ public class AddressEntityServiceImpl implements AddressEntityService {
 
 
     private final AddressRepository repository;
+    private final AddressServiceContract addressServiceContract;
 
     public AddressEntityServiceImpl(AddressRepository repository) {
         this.repository = repository;
+        this.addressServiceContract = new AddressService();
     }
 
     @Override
@@ -62,7 +65,7 @@ public class AddressEntityServiceImpl implements AddressEntityService {
         ValidationUtils.validateNotNullOrEmpty(address, ADDRESS_CREATION_ERROR, AddressEntityFailuresException.class);
         Address newAddress;
         try {
-            newAddress = AddressFactory.create(address.getStreet(), address.getNumber(), address.getNeighborhood(), address.getCity(), address.getState(), address.getZip());
+            newAddress = this.addressServiceContract.createAddress(address.getStreet(), address.getNumber(), address.getNeighborhood(), address.getCity(), address.getState(), address.getZip());
         } catch (AddressCreationFailureException e) {
             log.error(CREATION_FAILURE_LOG, e.getMessage(), e);
             throw new AddressEntityFailuresException(ADDRESS_CREATION_ERROR, e);

--- a/src/main/java/diegosneves/github/conectardoacoes/core/service/AddressService.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/core/service/AddressService.java
@@ -1,0 +1,30 @@
+package diegosneves.github.conectardoacoes.core.service;
+
+import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Address;
+import diegosneves.github.conectardoacoes.core.domain.shelter.factory.AddressFactory;
+import diegosneves.github.conectardoacoes.core.exception.AddressCreationFailureException;
+
+/**
+ * Essa classe é responsável por fornecer os serviços relacionados ao endereço.
+ * Ela implementa todas as assinaturas de métodos definidas na interface AddressServiceContract.
+ *
+ * <p>A classe inclui o seguinte método:</p>
+ * 1. {@code createAddress()} que é usado para criar um objeto endereço.
+ *
+ * <p>A classe {@link AddressService} faz uso do padrão de projeto Factory para a criação do objeto Address.
+ * Isso permite que a criação de um objeto Address seja feita de uma maneira que adira ao princípio da responsabilidade única.</p>
+ *
+ * <p>O método {@code createAddress()} pode lançar uma exceção {@link AddressCreationFailureException}, que deve ser manuseada corretamente
+ * no local onde o método é chamado.</p>
+ *
+ * @see AddressServiceContract
+ * @author diegoneves
+ * @since 1.2.0
+ */
+public class AddressService implements AddressServiceContract {
+
+    @Override
+    public Address createAddress(String street, String number, String neighborhood, String city, String state, String zip) throws AddressCreationFailureException {
+        return AddressFactory.create(street, number, neighborhood, city, state, zip);
+    }
+}

--- a/src/main/java/diegosneves/github/conectardoacoes/core/service/AddressServiceContract.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/core/service/AddressServiceContract.java
@@ -1,0 +1,42 @@
+package diegosneves.github.conectardoacoes.core.service;
+
+import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Address;
+import diegosneves.github.conectardoacoes.core.exception.AddressCreationFailureException;
+
+/**
+ * Esta interface define um contrato para um serviço responsável pelo gerenciamento de endereços na aplicação.
+ * <p>
+ * O serviço de endereço é fundamental para definir, criar e validar instâncias de {@link Address}, que representam informações de endereço em nossa aplicação.
+ * Este contrato especifica quais operações estão disponíveis para esses casos de uso.
+ * <p>
+ * A operação principal provida por esta interface é a criação de um novo endereço.
+ * Os componentes que utilizam este serviço devem seguir o contrato estabelecido neste interface para assegurar que eles obedecem às regras de negócio ao criar novos endereços.
+ * <p>
+ * Esta interface é projetada para ser utilizada com uma implementação que siga o princípio da inversão de dependência, permitindo que diferentes implementações
+ * possam ser injetadas conforme necessário sem afetar a funcionalidade geral do sistema.
+ *
+ * @author diegoneves
+ * @since 1.2.0
+ */
+public interface AddressServiceContract {
+
+    /**
+     * Método utilizado para criar uma nova instância da classe {@link Address}.
+     * <p>
+     * Este método recebe uma série de parâmetros que representam diferentes partes de um endereço. Ele utiliza esses parâmetros para construir uma nova instância da classe Address.
+     * A nova instância é então retornada para o código que chamou este método.
+     * <p>
+     * Se algum dos parâmetros estiver nulo ou em branco, este método lançará uma {@link AddressCreationFailureException}.
+     *
+     * @param street       O nome da rua do endereço. Não deve ser nulo ou em branco.
+     * @param number       O número da residência no endereço. Não deve ser nulo ou em branco.
+     * @param neighborhood O nome do bairro do endereço. Não deve ser nulo ou em branco.
+     * @param city         O nome da cidade do endereço. Não deve ser nulo ou em branco.
+     * @param state        O nome do estado do endereço. Não deve ser nulo ou em branco.
+     * @param zip          O código postal do endereço. Não deve ser nulo ou em branco.
+     * @return Uma nova instância da classe {@link Address} contendo as informações do endereço fornecido.
+     * @throws AddressCreationFailureException Se algum dos parâmetros estiver nulo ou em branco.
+     */
+    Address createAddress(String street, String number, String neighborhood, String city, String state, String zip) throws AddressCreationFailureException;
+
+}

--- a/src/test/java/diegosneves/github/conectardoacoes/core/service/AddressServiceTest.java
+++ b/src/test/java/diegosneves/github/conectardoacoes/core/service/AddressServiceTest.java
@@ -1,0 +1,43 @@
+package diegosneves.github.conectardoacoes.core.service;
+
+import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Address;
+import diegosneves.github.conectardoacoes.core.utils.UuidUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(SpringExtension.class)
+class AddressServiceTest {
+
+    public static final String STREET = "Rua";
+    public static final String NUMBER = "54";
+    public static final String NEIGHBORHOOD = "Bairro";
+    public static final String CITY = "Canoas";
+    public static final String STATE_ABBREVIATION = "RS";
+    public static final String ZIPCODE = "95000000";
+
+    @InjectMocks
+    private AddressService addressService;
+
+
+    @Test
+    void shouldCreateAddress() {
+        Address address = this.addressService.createAddress(STREET, NUMBER, NEIGHBORHOOD, CITY, STATE_ABBREVIATION, ZIPCODE);
+
+        assertNotNull(address);
+        assertNotNull(address.getId());
+        assertTrue(UuidUtils.isValidUUID(address.getId()));
+        assertEquals(STREET, address.getStreet());
+        assertEquals(NUMBER, address.getNumber());
+        assertEquals(NEIGHBORHOOD, address.getNeighborhood());
+        assertEquals(CITY, address.getCity());
+        assertEquals(STATE_ABBREVIATION, address.getState());
+        assertEquals(ZIPCODE, address.getZip());
+    }
+
+}


### PR DESCRIPTION
# Solicitação de Pull Request

## Status

- [x] In Progress
- [x] Ready to Merging

## Tipo

- [ ] Release
- [ ] Feature
- [x] Technical Debt
- [ ] Fix
- [ ] Test
- [ ] Refactor
- [ ] Documentation
- [ ] Performance

## Descrição

- **Commit** 0142f059cfa0a7a3d6a41914f6493f4b7def56b8:

  - **Alterações em**: `AddressServiceContract.java`
    - Implementada a interface que define um contrato para um serviço responsável pelo gerenciamento de endereços na aplicação.
    
  - **Alterações em**: `AddressService.java`
    - Criada a classe que implementa a `AddressServiceContract`. Esta classe é responsável por fornecer os serviços relacionados ao endereço e implementa todas as assinaturas de métodos definidas na interface.
   
  - **Alterações em**: `AddressEntityServiceImpl.java`
    - Realizada a substituição do uso de `AddressFactory` por `AddressServiceContract` para criação de novas instâncias do objeto `Address`.
    
  - **Alterações em**: `AddressServiceTest.java`
    - Criada a classe de teste para testar o serviço `AddressService`.

- **Nota**: Este commit foca em melhorar a lógica de serviço dos endereços e padronizar as regras de negócio ao criar novos endereços.

---