### PR TITLE
feat/i18 :art: [REST] - Implantação de Consulta à API externa de CEP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <sonar.coverage.exclusions>
             **/dto/**,
             **/model/**,
+            **/adapter/**,
             **/response/**,
             **/request/**,
             **/config/**,

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/adapter/HttpAdapter.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/adapter/HttpAdapter.java
@@ -1,0 +1,48 @@
+package diegosneves.github.conectardoacoes.adapters.rest.adapter;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Classe abstrata que fornece a base para adaptadores HTTP. Isto inclui a configuração de
+ * cabeçalhos HTTP e a instância do {@link RestTemplateSimpleWebClient} a ser usada para chamadas HTTP.
+ * <p>
+ * Esta classe é anotada como um {@link Component @Component} do Spring Framework e, portanto, é passível de
+ * detecção automática e autocinjeto durante a inicialização da aplicação.
+ * <p>
+ * Ele usa um conjunto de cabeçalhos HTTP padrão ao instanciar, que inclui a configuração do conteúdo e
+ * os tipos de aceitação para JSON.
+ * <p>
+ * O acesso aos campos protegidos é garantido através dos métodos {@code @Getter} e {@code @Setter},
+ * ambos definidos com {@code AccessLevel.PROTECTED}.
+ *
+ * @author diegoneves
+ * @since 1.2.0
+ */
+@Component
+@Getter(AccessLevel.PROTECTED)
+@Setter(AccessLevel.PROTECTED)
+public abstract class HttpAdapter {
+
+    protected RestTemplateSimpleWebClient restTemplateSimpleWebClient;
+    protected HttpHeaders headers;
+
+    /**
+     * Inicializa uma instância de {@link HttpAdapter} com cabeçalhos Http default e
+     * a instância de {@link RestTemplateSimpleWebClient}.
+     * <p>
+     * Os tipos de mídia de conteúdo e aceitação são definidos como JSON.
+     */
+    protected HttpAdapter() {
+        this.headers = new HttpHeaders();
+        this.headers.setContentType(MediaType.APPLICATION_JSON);
+        this.headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        this.restTemplateSimpleWebClient = new RestTemplateSimpleWebClient();
+    }
+}

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/adapter/RestTemplateSimpleWebClient.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/adapter/RestTemplateSimpleWebClient.java
@@ -1,0 +1,48 @@
+package diegosneves.github.conectardoacoes.adapters.rest.adapter;
+
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * A classe {@link RestTemplateSimpleWebClient} é um encapsulamento simples da classe {@link RestTemplate} do Spring Framework.
+ * Ela proporciona uma maneira conveniente de realizar requisições HTTP usando o RestTemplate.
+ * <p>
+ * Esta classe é anotada com {@link Component @Component}, tornando-a elegível para detecção automática e
+ * auto-configuração como um bean do Spring.
+ * <p>
+ * Esta classe possui um único construtor que inicializa o objeto {@link RestTemplate}.
+ * <p>
+ * Exemplo de uso:
+ *<pre>{@code
+ * RestTemplateSimpleWebClient cliente = new RestTemplateSimpleWebClient();
+ *
+ * cliente.getRestTemplate().getForObject(url, tipoResposta);
+ * cliente.getRestTemplate().postForObject(url, requisição, tipoResposta);
+ * cliente.getRestTemplate().put(url, requisição);
+ * cliente.getRestTemplate().delete(url);
+ *
+ * }</pre>
+ *
+ * Nota: substitua url, tipoResposta, requisição com valores adequados de acordo com seu caso de uso.
+ * <p>
+ * Esta classe fornece um método getter público para acesso ao objeto {@link RestTemplate}:
+ *
+ * <pre>{@code RestTemplate restTemplate = cliente.getRestTemplate();}</pre>
+ *
+ * A classe {@link RestTemplateSimpleWebClient} é tipicamente utilizada em conjunto com outras classes,
+ * como HttpHeaders, para realizar requisições HTTP com headers apropriados.
+ *
+ * @author diegosneves
+ */
+@Component
+@Getter
+public class RestTemplateSimpleWebClient {
+
+    private final RestTemplate restTemplate;
+
+    public RestTemplateSimpleWebClient() {
+        this.restTemplate = new RestTemplate();
+    }
+
+}

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/adapter/RetrieveAddressAdapter.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/adapter/RetrieveAddressAdapter.java
@@ -28,7 +28,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class RetrieveAddressAdapter extends HttpAdapter {
 
     private static final String JSON_PATH = "json";
-    public static final Integer CEP_RETRIEVAL_FAILURE = 12;
+    public static final Integer ZIPCODE_RETRIEVAL_FAILURE = 12;
 
     private final String url;
 
@@ -55,7 +55,7 @@ public class RetrieveAddressAdapter extends HttpAdapter {
             return response.getBody();
         } catch (RestClientException e) {
             log.error(e.getLocalizedMessage(), e);
-            throw new ExternalApiFailureException(CEP_RETRIEVAL_FAILURE, zipcode, e);
+            throw new ExternalApiFailureException(ZIPCODE_RETRIEVAL_FAILURE, zipcode, e);
         }
     }
 

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/adapter/RetrieveAddressAdapter.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/adapter/RetrieveAddressAdapter.java
@@ -1,0 +1,62 @@
+package diegosneves.github.conectardoacoes.adapters.rest.adapter;
+
+import diegosneves.github.conectardoacoes.adapters.rest.exception.ExternalApiFailureException;
+import diegosneves.github.conectardoacoes.adapters.rest.response.AddressApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * Classe concreta estendendo {@link HttpAdapter}, responsável por recuperar informações de endereço
+ * com base no CEP fornecido.
+ * <p>
+ * Ela quer dizer que a classe é detectável durante a inicialização do Spring para injeção de dependência e bem
+ * como para logging respectivamente.
+ * <p>
+ * O {@link Autowired @Autowired} em seu contrutor garante a injeção automática de valores da propriedade do Spring.
+ *
+ * @author diegoneves
+ * @since 1.2.0
+ */
+@Component
+@Slf4j
+public class RetrieveAddressAdapter extends HttpAdapter {
+
+    private static final String JSON_PATH = "json";
+    public static final Integer CEP_RETRIEVAL_FAILURE = 12;
+
+    private final String url;
+
+    @Autowired
+    public RetrieveAddressAdapter(@Value("${spring.api.url.via-cep}") String url) {
+        this.url = url;
+    }
+
+    /**
+     * Recupera informações de endereço com base no CEP fornecido usando a URL fornecida.
+     * <p>
+     * Este método utiliza o {@link RestTemplate} para fazer a chamada para a API e retorna o corpo da
+     * resposta como um {@link AddressApiResponse AddressApiResponse}.
+     *
+     * @param zipcode O CEP para o qual recuperar as informações de endereço.
+     * @return Um objeto {@link AddressApiResponse AddressApiResponse} contendo os detalhes do endereço.
+     * @throws ExternalApiFailureException Se houver um erro ao fazer a chamada para a API.
+     */
+    public AddressApiResponse retrieveAddress(String zipcode) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(this.url).pathSegment(zipcode, JSON_PATH);
+        try {
+            ResponseEntity<AddressApiResponse> response = this.restTemplateSimpleWebClient.getRestTemplate()
+                    .getForEntity(builder.toUriString(), AddressApiResponse.class);
+            return response.getBody();
+        } catch (RestClientException e) {
+            log.error(e.getLocalizedMessage(), e);
+            throw new ExternalApiFailureException(CEP_RETRIEVAL_FAILURE, zipcode, e);
+        }
+    }
+
+}

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/config/web/OpenApiConfig.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/config/web/OpenApiConfig.java
@@ -45,7 +45,7 @@ public class OpenApiConfig {
      */
     private Info getInfo() {
         return new Info()
-                .version("v1.0.0")
+                .version("v1.2.0")
                 .title("Conectar Doações")
                 .description("API de conexão de doadores e organização de doações")
                 .contact(new Contact().email("neves.diegoalex@outlook.com").url("https://github.com/diegosneves/conectar-doacoes").name("Diego Neves"));
@@ -59,6 +59,7 @@ public class OpenApiConfig {
      */
     private List<Tag> getTags() {
         return List.of(
+                new Tag().name("Endereços").description("Funcionalidades direcionadas para os Endereços"),
                 new Tag().name("Usuários").description("Funcionalidades direcionadas para os Usuários"),
                 new Tag().name("Abrigos").description("Funcionalidades direcionadas para os Abrigos"));
     }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/controller/AddressController.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/controller/AddressController.java
@@ -1,0 +1,62 @@
+package diegosneves.github.conectardoacoes.adapters.rest.controller;
+
+import diegosneves.github.conectardoacoes.adapters.rest.dto.AddressApiResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+/**
+ * Interface para controlar operações de endereço.
+ *
+ * <p>Esta interface fornece uma abstração para as operações realizadas em um endereço.
+ * As operações realizadas por esta interface incluem a recuperação de um endereço
+ * com base em seu código postal/zipe code.</p>
+ *
+ * <p>Esta interface faz uso de um serviço externo para buscar um endereço
+ * e retorna uma representação do endereço como um {@code AddressApiResponseDTO}.
+ * Cada operação é mapeada para um endpoint específico para fácil uso via REST.</p>
+ *
+ * <p>Para usar essa interface, um cliente REST precisará acessar o
+ * endpoint correspondente e fornecer os parâmetros necessários.</p>
+ *
+ * @author diegoneves
+ * @since 1.2.0
+ */
+public interface AddressController {
+
+    /**
+     * Obtém um dado Endereço, fazendo uso de um serviço externo.<br>
+     * <br>
+     * Este é um método HTTP GET que é mapeado para o seguinte URL: /{zipcode}.
+     * Ele usa a anotação @Operation para fornecer uma descrição de alto nível da operação
+     * e a anotação @ApiResponses para descrever as possíveis respostas da operação.
+     *
+     * @param zipcode O código postal do local para o qual se quer obter a informação do endereço. É um valor obrigatório e é informado na URL.
+     * @return {@code ResponseEntity<AddressApiResponseDTO>} O objeto {@link AddressApiResponseDTO} encapsulado em um {@link ResponseEntity}.
+     * O objeto AddressApiResponse contém informações detalhadas sobre o endereço.
+     * O ResponseEntity é uma extensão do HttpEntity que adiciona um código HttpStatus a ele.
+     * A ResponseEntity retorna o endereço obtido com sucesso!
+     * @throws diegosneves.github.conectardoacoes.adapters.rest.exception.ExternalApiFailureException Se o endereço com o código postal fornecido não for encontrado.
+     * @see AddressApiResponseDTO
+     */
+    @GetMapping(value = "/{zipcode}")
+    @Operation(
+            summary = "Obtém um Endereço",
+            description = "Esse endpoint tem a função de obter um determinado Endereço fazendo uso de um serviço externo.",
+            tags = "Endereços"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Endereço obtido com sucesso!",
+                    content = @Content(schema = @Schema(implementation = AddressApiResponseDTO.class))
+            )
+    })
+    ResponseEntity<AddressApiResponseDTO> retrieveAddress(@PathVariable("zipcode") String zipcode);
+
+}

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/controller/imp/AddressControllerImpl.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/controller/imp/AddressControllerImpl.java
@@ -1,0 +1,40 @@
+package diegosneves.github.conectardoacoes.adapters.rest.controller.imp;
+
+import diegosneves.github.conectardoacoes.adapters.rest.controller.AddressController;
+import diegosneves.github.conectardoacoes.adapters.rest.dto.AddressApiResponseDTO;
+import diegosneves.github.conectardoacoes.adapters.rest.service.AddressEntityService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/**
+ * Controladora REST para gerenciar o endereçamento. Esta classe roteia as requisições
+ * HTTP relacionadas a endereço que chegam em "/address" para o serviço correspondente.
+ * Implementa a interface {@link AddressController}.
+ * <p>
+ * Esta classe contém:
+ * uma instância de AddressEntityService que é usada para acessar o serviço correspondente à entidade de endereços.
+ *
+ * @author diegoneves
+ * @since 1.2.0
+ * @see AddressEntityService
+ */
+@RestController
+@RequestMapping("/address")
+public class AddressControllerImpl implements AddressController {
+
+    private final AddressEntityService addressEntityService;
+
+    @Autowired
+    public AddressControllerImpl(AddressEntityService addressEntityService) {
+        this.addressEntityService = addressEntityService;
+    }
+
+    @Override
+    public ResponseEntity<AddressApiResponseDTO> retrieveAddress(String zipcode) {
+        AddressApiResponseDTO addressApiResponseDTO = this.addressEntityService.restrieveAddress(zipcode);
+        return ResponseEntity.ok(addressApiResponseDTO);
+    }
+}

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/dto/AddressApiResponseDTO.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/dto/AddressApiResponseDTO.java
@@ -6,6 +6,26 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * Essa é a classe {@link AddressApiResponseDTO} que representa a resposta da API para um endereço.
+ * Esta classe contém todos os detalhes referentes a um endereço que o serviço pode retornar.
+ *
+ * <p> A classe é montada utilizando o padrão de projeto Builder para facilitar a criação de
+ * instâncias e melhorar a legibilidade do código. Os atributos incluem dados como {@code rua},
+ * {@code bairro}, {@code cidade}, {@code estado} e {@code CEP} do endereço.
+ *
+ * <p> Os seguintes atributos estão presentes nesta classe:
+ * <ul>
+ *     <li> {@code street} - Um campo String que representa o nome da rua do endereço.
+ *     <li> {@code neighborhood} - Um campo String que representa o bairro do endereço.
+ *     <li> {@code city} - Um campo String que representa a cidade do endereço.
+ *     <li> {@code state} - Um campo String que representa o estado do endereço.
+ *     <li> {@code zip} - Um campo String que representa o CEP (Código de Endereçamento Postal) do endereço.
+ * </ul>
+ *
+ * @author diegoneves
+ * @since 1.2.0
+ */
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/dto/AddressApiResponseDTO.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/dto/AddressApiResponseDTO.java
@@ -1,0 +1,22 @@
+package diegosneves.github.conectardoacoes.adapters.rest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class AddressApiResponseDTO {
+
+    private String street;
+    private String neighborhood;
+    private String city;
+    private String state;
+    private String zip;
+
+}

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/enums/ExceptionDetails.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/enums/ExceptionDetails.java
@@ -27,7 +27,7 @@ public enum ExceptionDetails {
     RESPONSIBLE_USER_ALREADY_IN_USE(9, "Este usuário já possui responsabilidade sobre outro abrigo.", HttpStatus.FORBIDDEN),
     EMAIL_ALREADY_IN_USE(10, "Desculpe, o endereço de email %s , já está associado a uma conta existente. Por favor,tente com um email diferente.", HttpStatus.FORBIDDEN),
     USER_RESPONSIBLE_EMAIL_NOT_FOUND_ERROR(11, "Ops! Não conseguimos encontrar o e-mail do usuário responsável. Por gentileza, tente novamente.", HttpStatus.NOT_FOUND),
-    CEP_RETRIEVAL_FAILURE(12, "Falha ao recuperar o endereço com o CEP fornecido (%s). Por favor, verifique se o CEP está correto e tente novamente em alguns instantes.", HttpStatus.BAD_REQUEST),
+    ZIPCODE_RETRIEVAL_FAILURE(12, "Falha ao recuperar o endereço com o CEP fornecido (%s). Por favor, verifique se o CEP está correto e tente novamente em alguns instantes.", HttpStatus.BAD_REQUEST),
     DONATION_VALIDATION_ERROR(13, "Para o cadastro de doações, é indispensável o fornecimento de informações válidas e completas.", HttpStatus.BAD_REQUEST),
     EMPTY_DONATION_LIST(15, "Até o momento, não há doações listadas.", HttpStatus.BAD_REQUEST),
     RESPONSIBLE_EMAIL_NOT_ASSOCIATED_WITH_SHELTER(17, "Por favor, verifique se o e-mail do usuário responsável está correto e associado a um abrigo. Caso contrário, certifique-se de que o usuário responsável tenha um e-mail válido em nosso sistema.", HttpStatus.BAD_REQUEST),
@@ -39,7 +39,8 @@ public enum ExceptionDetails {
     INVALID_EMAIL_ERROR_MESSAGE(29, "Não foi informado nenhum email. Por favor, forneça um email válido.", HttpStatus.BAD_REQUEST),
     USER_CREATION_FAILURE_MESSAGE(31, "Ops! A criação do novo usuário não foi bem-sucedida. Por favor, certifique-se de que seus dados estão corretos e tente novamente.", HttpStatus.BAD_REQUEST),
     USER_PROFILE_VALIDATION_FAILURE(33, "A validação do Perfil do usuário fornecido falhou.", HttpStatus.BAD_REQUEST),
-    REQUIRED_USER_ERROR_MESSAGE(35, "Um usuário válido é requerido para efetuar a persistência.", HttpStatus.BAD_REQUEST);
+    REQUIRED_USER_ERROR_MESSAGE(35, "Um usuário válido é requerido para efetuar a persistência.", HttpStatus.BAD_REQUEST),
+    ZIPCODE_INVALID_FAILURE(37, "Falha ao tentar recuperar o endereço com o CEP fornecido. Por favor, verifique se o CEP está correto e tente novamente", HttpStatus.BAD_REQUEST);
 
 
     public static final String EXCEPTION_PREFIX = "T%03dF - ";

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/enums/ExceptionDetails.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/enums/ExceptionDetails.java
@@ -27,6 +27,7 @@ public enum ExceptionDetails {
     RESPONSIBLE_USER_ALREADY_IN_USE(9, "Este usuário já possui responsabilidade sobre outro abrigo.", HttpStatus.FORBIDDEN),
     EMAIL_ALREADY_IN_USE(10, "Desculpe, o endereço de email %s , já está associado a uma conta existente. Por favor,tente com um email diferente.", HttpStatus.FORBIDDEN),
     USER_RESPONSIBLE_EMAIL_NOT_FOUND_ERROR(11, "Ops! Não conseguimos encontrar o e-mail do usuário responsável. Por gentileza, tente novamente.", HttpStatus.NOT_FOUND),
+    CEP_RETRIEVAL_FAILURE(12, "Falha ao recuperar o endereço com o CEP fornecido (%s). Por favor, verifique se o CEP está correto e tente novamente em alguns instantes.", HttpStatus.BAD_REQUEST),
     DONATION_VALIDATION_ERROR(13, "Para o cadastro de doações, é indispensável o fornecimento de informações válidas e completas.", HttpStatus.BAD_REQUEST),
     EMPTY_DONATION_LIST(15, "Até o momento, não há doações listadas.", HttpStatus.BAD_REQUEST),
     RESPONSIBLE_EMAIL_NOT_ASSOCIATED_WITH_SHELTER(17, "Por favor, verifique se o e-mail do usuário responsável está correto e associado a um abrigo. Caso contrário, certifique-se de que o usuário responsável tenha um e-mail válido em nosso sistema.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/ExternalApiFailureException.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/exception/ExternalApiFailureException.java
@@ -1,0 +1,46 @@
+package diegosneves.github.conectardoacoes.adapters.rest.exception;
+
+import diegosneves.github.conectardoacoes.adapters.rest.enums.ExceptionDetails;
+
+/**
+ * Classe {@link ExternalApiFailureException} se estende da classe {@link CustomException} e é utilizada para lidar com os erros de interação com APIs externas.
+ * <p>
+ * Quando um método que invoca uma API externa encontra erros, ele gera uma nova instância desta exceção, passando informações relevantes como argumentos para o construtor.
+ * Estas informações incluem um código de erro em forma de número inteiro, uma mensagem de erro customizada, e a causa original do erro.
+ * Esta exceção é então capturada pela lógica do programa para fins de tratamento de erro e logging.
+ * <p>
+ * A chave do erro, representada por um número inteiro, é utilizada para recuperar informações detalhadas da exceção ({@link ExceptionDetails}) associadas a tal erro através do método
+ * {@link ExternalApiFailureException#obtainExceptionDetails}.
+ * Note que se nenhum {@link ExceptionDetails} é encontrado para a referida chave, uma {@link CustomException} poderá ser lançada pelo método {@link ExternalApiFailureException#obtainExceptionDetails}.
+ * <p>
+ * Portanto, a intenção desta classe é encapsular os detalhes de erros que podem ocorrer durante a interação com APIs externas, permitindo que o restante do código lide com esses erros
+ * de uma maneira mais abstrata e controlada.
+ *
+ * @author diegoneves
+ * @since 1.2.0
+ * @see CustomException
+ * @see RuntimeException
+ */
+public class ExternalApiFailureException extends CustomException {
+
+    /**
+     * Construtor para criar uma nova instância de {@link ExternalApiFailureException}.
+     * <p>
+     * Este construtor é chamado quando há um erro ao tentar recuperar informações da API externa.
+     * Ele passa os detalhes do erro na forma de um número inteiro (representando uma chave específica de erro),
+     * uma mensagem de erro personalizada e a causa original do erro para o construtor da superclasse {@link CustomException}.
+     * <p>
+     * Os detalhes da exceção são obtidos chamando o método {@link ExternalApiFailureException#obtainExceptionDetails}
+     * com o termo fornecido como argumento. Esta chamada pode resultar em uma {@link CustomException} se nenhum {@link ExceptionDetails}
+     * for encontrado para o termo dado.
+     *
+     * @param term    A chave do erro, representado por um número inteiro. Usado para recuperar o {@link ExceptionDetails} associado.
+     * @param message A mensagem de erro customizada.
+     * @param cause   A causa root que levou a esta exceção, habitualmente a exceção jogada pela API externa. Representada
+     *                como um objeto {@link Throwable}. Um valor nulo é permitido e indica que a causa é inexistente ou desconhecida.
+     * @throws ExternalApiFailureException A exceção lançada quando uma chamada para a API externa falha.
+     */
+    public ExternalApiFailureException(Integer term, String message, Throwable cause) {
+        super(obtainExceptionDetails(term), message, cause);
+    }
+}

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/response/AddressApiResponse.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/response/AddressApiResponse.java
@@ -8,6 +8,22 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * Representa a resposta de uma requisição à API de Endereços.
+ * <p>
+ * A classe é utilizada para deserializar dados de resposta da API de Endereços,
+ * que são então usados para converter em um objeto {@link AddressApiResponseDTO}.
+ * <p>
+ * A classe está anotada para uso com a biblioteca Jackson, que cuida da deserialização do {@code JSON} retornado pela API.
+ * Os campos são mapeados para nomes específicos do {@code JSON} usando a anotação {@link JsonProperty}.
+ * <p>
+ * Além disso, a classe incorpora o padrão {@code Builder} por meio da anotação {@code Builder} do Lombok,
+ * permitindo a criação de instâncias de maneira versátil e segura.
+ *
+ * @author diegoneves
+ * @see AddressApiResponseDTO
+ * @since 1.2.0
+ */
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
@@ -26,6 +42,13 @@ public class AddressApiResponse {
     @JsonProperty("cep")
     private String zip;
 
+    /**
+     * Este método é responsável por converter os dados presentes na instância atual da classe {@link AddressApiResponse} para uma nova instância da classe {@link AddressApiResponseDTO}.
+     * <p>
+     * Utiliza o método {@code builder()} da classe {@link AddressApiResponseDTO} para instanciar um novo {@link AddressApiResponseDTO}.
+     *
+     * @return Uma nova instância de {@link AddressApiResponseDTO} que contém os mesmos dados que a instância atual de {@link AddressApiResponse}.
+     */
     public AddressApiResponseDTO convertToDTO() {
         return AddressApiResponseDTO.builder()
                 .street(this.street)

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/response/AddressApiResponse.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/response/AddressApiResponse.java
@@ -1,0 +1,39 @@
+package diegosneves.github.conectardoacoes.adapters.rest.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import diegosneves.github.conectardoacoes.adapters.rest.dto.AddressApiResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class AddressApiResponse {
+
+    @JsonProperty("logradouro")
+    private String street;
+    @JsonProperty("bairro")
+    private String neighborhood;
+    @JsonProperty("localidade")
+    private String city;
+    @JsonProperty("uf")
+    private String state;
+    @JsonProperty("cep")
+    private String zip;
+
+    public AddressApiResponseDTO convertToDTO() {
+        return AddressApiResponseDTO.builder()
+                .street(this.street)
+                .neighborhood(this.neighborhood)
+                .city(this.city)
+                .state(this.state)
+                .zip(this.zip)
+                .build();
+    }
+
+}

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/AddressEntityService.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/AddressEntityService.java
@@ -1,5 +1,6 @@
 package diegosneves.github.conectardoacoes.adapters.rest.service;
 
+import diegosneves.github.conectardoacoes.adapters.rest.dto.AddressApiResponseDTO;
 import diegosneves.github.conectardoacoes.adapters.rest.dto.AddressDTO;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.AddressEntityFailuresException;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Address;
@@ -37,4 +38,20 @@ public interface AddressEntityService {
      */
     Address createAndSaveAddressFromDto(AddressDTO address) throws AddressEntityFailuresException;
 
+    /**
+     * Recupera um endereço usando o CEP fornecido.
+     * <p>
+     * Este método tem como objetivo fazer uma requisição para recuperar um endereço através de um CEP fornecido
+     * como parâmetro, retornando um objeto {@link AddressApiResponseDTO} contendo os detalhes do endereço.
+     * <p>
+     * O método interage com um serviço {@link diegosneves.github.conectardoacoes.adapters.rest.adapter.RetrieveAddressAdapter} para realizar a requisição e obter a resposta correspondente.
+     * Após obter a resposta, a mesma é convertida para {@link AddressApiResponseDTO} e retorna ao chamador.
+     * Em caso de falha na recuperação do endereço, como por exemplo CEP nulo ou vazio, uma exceção {@link AddressEntityFailuresException} será lançada.
+     *
+     * @param zipcode Um {@link String} que representa o CEP para o qual o endereço precisa ser recuperado.
+     * @return Um objeto {@link AddressApiResponseDTO} que representa o endereço recuperado do CEP fornecido.
+     * @throws AddressEntityFailuresException Se o {@code zipcode} recebido for nulo ou vázio.
+     * @throws diegosneves.github.conectardoacoes.adapters.rest.exception.ExternalApiFailureException Se ocorrer uma falha durante a recuperação do endereço.
+     */
+    AddressApiResponseDTO restrieveAddress(String zipcode);
 }

--- a/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/AddressEntityServiceImpl.java
+++ b/src/main/java/diegosneves/github/conectardoacoes/adapters/rest/service/impl/AddressEntityServiceImpl.java
@@ -1,11 +1,14 @@
 package diegosneves.github.conectardoacoes.adapters.rest.service.impl;
 
+import diegosneves.github.conectardoacoes.adapters.rest.adapter.RetrieveAddressAdapter;
+import diegosneves.github.conectardoacoes.adapters.rest.dto.AddressApiResponseDTO;
 import diegosneves.github.conectardoacoes.adapters.rest.dto.AddressDTO;
 import diegosneves.github.conectardoacoes.adapters.rest.exception.AddressEntityFailuresException;
 import diegosneves.github.conectardoacoes.adapters.rest.mapper.AddressEntityMapper;
 import diegosneves.github.conectardoacoes.adapters.rest.mapper.BuilderMapper;
 import diegosneves.github.conectardoacoes.adapters.rest.model.AddressEntity;
 import diegosneves.github.conectardoacoes.adapters.rest.repository.AddressRepository;
+import diegosneves.github.conectardoacoes.adapters.rest.response.AddressApiResponse;
 import diegosneves.github.conectardoacoes.adapters.rest.service.AddressEntityService;
 import diegosneves.github.conectardoacoes.core.domain.shelter.entity.value.Address;
 import diegosneves.github.conectardoacoes.core.exception.AddressCreationFailureException;
@@ -50,13 +53,16 @@ public class AddressEntityServiceImpl implements AddressEntityService {
     public static final String CREATION_FAILURE_LOG = "Falha na tentativa de criação de um novo Endereço. Causa do erro: {}";
     public static final String ADDRESS_MAPPING_ERROR_LOG = "Ocorreu uma falha ao tentar mapear o Endereço. Causa do erro: {}";
     public static final String ADDRESS_REGISTRATION_SUCCESS_LOG = "Novo endereço registrado com êxito! Identificador do endereço (ID): {} - Código Postal (ZIPCODE): {}";
+    public static final int ZIPCODE_INVALID_FAILURE = 37;
 
 
     private final AddressRepository repository;
     private final AddressServiceContract addressServiceContract;
+    private final RetrieveAddressAdapter addressAdapter;
 
-    public AddressEntityServiceImpl(AddressRepository repository) {
+    public AddressEntityServiceImpl(AddressRepository repository, RetrieveAddressAdapter addressAdapter) {
         this.repository = repository;
+        this.addressAdapter = addressAdapter;
         this.addressServiceContract = new AddressService();
     }
 
@@ -94,4 +100,10 @@ public class AddressEntityServiceImpl implements AddressEntityService {
         log.info(ADDRESS_REGISTRATION_SUCCESS_LOG, address.getId(), address.getZip());
     }
 
+    @Override
+    public AddressApiResponseDTO restrieveAddress(String zipcode) {
+        ValidationUtils.validateNotNullOrEmpty(zipcode, ZIPCODE_INVALID_FAILURE, AddressEntityFailuresException.class);
+        AddressApiResponse addressApiResponse = this.addressAdapter.retrieveAddress(zipcode);
+        return addressApiResponse.convertToDTO();
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,10 @@ spring:
       ddl-auto: update
     show-sql: true
 
+  api:
+    url:
+      via-cep: https://viacep.com.br/ws/
+
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
# Solicitação de Pull Request

## Status

- [x] In Progress
- [x] Ready to Merging

## Tipo

- [ ] Release
- [x] Feature
- [ ] Technical Debt
- [ ] Fix
- [ ] Test
- [ ] Refactor
- [ ] Documentation
- [ ] Performance

## Descrição

- **Commit** f2b00eb7582eff8b0aab67e401b267dbe90d8c53:

  - **Alterações em**: `OpenApiConfig.java`
    - Atualizada a versão da API de `v1.0.0` para `v1.2.0`.
    - Adicionada a tag "Endereços" à lista de tags.

  - **Alterações em**: `ExceptionDetails.java`
    - Adicionada a exceção `CEP_RETRIEVAL_FAILURE` ao enum.
  
  - **Alterações em**: `ExternalApiFailureException.java`
    - Criada a nova classe `ExternalApiFailureException` para tratar erros de chamadas de APIs externas.
  
  - **Alterações em**: `application.yaml`
    - Adicionada a URL base do serviço Via CEP ao arquivo de configuração.

- **Nota**: Este commit é focado em tratar falhas ao interagir com APIs externas, em particular com o serviço Via CEP, adicionando uma nova exceção para encapsular tais falhas e incluindo a URL do serviço Via CEP no arquivo de configurações do projeto.

---

- **Commit** c1b0082df977acde04ce082ab9193ad038ecd46c:

  - **Alterações em**: `pom.xml`
     - A pasta `adapter` foi excluída da cobertura de testes do Sonar.
   
  - **Alterações em**: `HttpAdapter.java`
     - Criada a classe abstrata `HttpAdapter` que configura os cabeçalhos HTTP e instancia o `RestTemplateSimpleWebClient` para chamadas HTTP.
     
  - **Alterações em**: `RestTemplateSimpleWebClient.java`
     - Criada a classe `RestTemplateSimpleWebClient` que encapsula a classe `RestTemplate` do Spring Framework para realizar requisições HTTP.
     
  - **Alterações em**: `RetrieveAddressAdapter.java`
     - Criado o `RetrieveAddressAdapter` que estende o `HttpAdapter` e recupera informações de endereço com base no CEP fornecido.
  
  - **Alterações em**: `AddressApiResponseDTO.java`
     - Criada a classe `AddressApiResponseDTO` representando um Data Transfer Object da resposta da API de endereços.
     
  - **Alterações em**: `AddressApiResponse.java`
     - Criada a classe `AddressApiResponse` representando a resposta da API ao recuperar informações de endereços. Dentre suas funções, ela possui um método que converte a resposta da API em uma instância `AddressApiResponseDTO`.

- **Nota**: Este commit se concentra na criação das classes necessárias para realizar chamadas de API para recuperar informações de endereços baseados no CEP. Estas novas classes permitem a recuperação de endereços e a subsequente conversão da resposta da API em DTO

---

- **Commit** b2ca4151ed8b43c1b4e02abdcb1fe95553872ba1:
  
  - **Alterações em**: `RetrieveAddressAdapter.java`
    - Renomeada a constante `CEP_RETRIEVAL_FAILURE` para `ZIPCODE_RETRIEVAL_FAILURE`.
   
  - **Adições**: `AddressController.java` e `AddressControllerImpl.java`
    - Criado um novo arquivo: `AddressController.java`, que contém a abstração para as operações realizadas em um endereço.
    - Criado um novo arquivo: `AddressControllerImpl.java`, que implementa a interface `AddressController` e realiza a conexão ao serviço `AddressEntityService`.
  
  - **Alterações em**: `AddressController.java`
    - Criado um novo endereço mapeado para /{zipcode}, por meio do método `retrieveAddress`, que usa zipcode como parâmetro para obter o endereço.

  - **Alterações em**: `AddressControllerImpl.java`
    - Implementação do método `retrieveAddress` que busca o serviço `AddressEntityService`.

  - **Alterações em**: `AddressApiResponseDTO.java` e `ExceptionDetails.java`
    - Adicionada documentação à classe `AddressApiResponseDTO.java`.
    - Renomeada a constante `CEP_RETRIEVAL_FAILURE` para `ZIPCODE_RETRIEVAL_FAILURE`  na enum `ExceptionDetails.java`.
  
- **Nota**: Este commit tem como objetivo introduzir a funcionalidade de obter informações de endereços utilizando o código postal por meio de um novo endpoint.

---

- **Commit** a0161d38390e63f86b07d23cef14178b87c16a06:

  - **Alterações em**: `AddressEntityService.java`
    - Adicionado o método "restrieveAddress", que é usado para recuperar um endereço usando um CEP fornecido.

  - **Alterações em**: `AddressEntityServiceImpl.java`
    - Implementação do método "restrieveAddress", que utiliza o serviço `RetrieveAddressAdapter` para fazer a requisição e obter a resposta correspondente.
    - A resposta é convertida para `AddressApiResponseDTO` e retorna ao chamador.

  - **Alterações em**: `AddressEntityServiceImplTest.java`
    - Adicionados testes unitários para o novo método "restrieveAddress".
    - Os testes incluem o tratamento de exceções para CEPs nulos, vazios ou inválidos.
    
- **Nota**: Este commit tem como foco adicionar a funcionalidade de recuperação de endereços através de um CEP fornecido por meio do novo método `restrieveAddress`.

